### PR TITLE
ci(semantic-release): Specify repositoryUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ITK/VTK Image Viewer",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kitware/itk-vtk-viewer.git"
+    "url": "https://github.com/kitware/itk-vtk-viewer.git"
   },
   "license": "BSD-3-Clause",
   "bugs": {


### PR DESCRIPTION
For publishing. The GIT_PUBLISH_URL is setup in .travis.yml. Use for
repositoryUrl if set.

This helps semantic-release pick up the correct publish URL.

As documented:
https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#repositoryurl