### PR TITLE
Fix tooltips blocking interactions

### DIFF
--- a/src/userInterface/ItkVtkViewer.module.css
+++ b/src/userInterface/ItkVtkViewer.module.css
@@ -83,6 +83,7 @@
 }
 [itk-vtk-tooltip]::before {
     content: attr(itk-vtk-tooltip-content);
+    visibility: hidden;
     display: block;
     position: absolute;
     top: 50%;
@@ -107,6 +108,7 @@
 
 [itk-vtk-tooltip]:hover::before {
     opacity: 1;
+    visibility: visible;
     transform: translate(0, -50%);
 }
 


### PR DESCRIPTION
Fixes a specific, annoying issue where the "Volume Spacing Distance" and "Gradient Opacity" tooltips pop up and block interactions with the windowing canvas. This fix makes the tooltips only popup when hovering over the relevant icons.
Tested on Firefox 66.0.3 x64 on Windows 10