### PR TITLE
ci(npm): Use npm ci instead of npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ node_js:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libgif-dev
-  - npm i -g npm@6.1.0
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
   - sleep 3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: 'Install Node.js'
 
   - script: |
-      npm install
+      npm ci
       npm run build
     displayName: 'Build'
 
@@ -73,6 +73,6 @@ jobs:
     displayName: 'Install Node.js'
 
   - script: |
-      npm install
+      npm ci
       npm run build
     displayName: 'Build'


### PR DESCRIPTION
This is the preferred command for deployment that uses package-lock.json.