### PR TITLE
ci(Travis): Disable npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
   chrome: stable
 node_js:
   - '10'
+cache:
+  npm: false
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libgif-dev


### PR DESCRIPTION
To address the error discussed:

  https://travis-ci.community/t/npm-ci-will-fail-if-cached-dependency-includes-npm/4203