### PR TITLE
ci(Travis): Use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libgif-dev
 install:
-  - npm ci
+  - npm install
 
 notifications:
   email:
@@ -33,7 +33,6 @@ cache:
     - doc/build-tmp
 
 script:
-  - npm ci
   - npm run build:release
   - git config --global user.name "Travis CI"
   - git config --global user.email "sebastien.jourdain@kitware.com"


### PR DESCRIPTION
A workaround for: https://travis-ci.community/t/npm-ci-will-fail-if-cached-dependency-includes-npm/4203