### PR TITLE
fix(ItkVtkViewProxy): Do not animate when mouseover volume rendering

### DIFF
--- a/src/ItkVtkViewProxy.js
+++ b/src/ItkVtkViewProxy.js
@@ -144,10 +144,14 @@ function ItkVtkViewProxy(publicAPI, model) {
     updateAnnotations(event);
   });
   model.interactor.onStartMouseMove((event) => {
-    publicAPI.getInteractor().requestAnimation('annotationMouseMove');
+    if (model.viewMode !== 'VolumeRendering' || model.viewPlanes) {
+      publicAPI.getInteractor().requestAnimation('annotationMouseMove');
+    }
   });
   model.interactor.onEndMouseMove((event) => {
-    publicAPI.getInteractor().cancelAnimation('annotationMouseMove');
+    if (model.viewMode !== 'VolumeRendering' || model.viewPlanes) {
+      publicAPI.getInteractor().cancelAnimation('annotationMouseMove');
+    }
   });
   model.interactor.onEndMouseWheel((event) => {
     updateDataProbeSize();


### PR DESCRIPTION
This preserves a high quality volume rendering when the mouse is moving
over the volume. We still request animation when the slicing planes are
enabled so the cursor widget is updated.