### PR TITLE
Export utility functions for customizing the viewer

### DIFF
--- a/src/ItkVtkViewProxy.js
+++ b/src/ItkVtkViewProxy.js
@@ -274,7 +274,9 @@ function ItkVtkViewProxy(publicAPI, model) {
   model.interactor.onEndPinch(updateScaleBar);
 
   // API ----------------------------------------------------------------------
-
+  publicAPI.updateDataProbeSize = updateDataProbeSize;
+  publicAPI.updateScaleBar = updateScaleBar;
+  
   publicAPI.setViewMode = (mode) => {
     if (model.viewMode === 'VolumeRendering') {
       model.volumeRenderingCameraState = model.camera.getState();

--- a/src/UserInterface/createImageUI.js
+++ b/src/UserInterface/createImageUI.js
@@ -151,6 +151,7 @@ function createImageUI(store, use2D) {
 
   }
 
+
   store.mainUI.uiContainer.appendChild(imageUIGroup);
 
   const haveLabelMap = !!store.imageUI.labelMap;

--- a/src/UserInterface/createMainUI.js
+++ b/src/UserInterface/createMainUI.js
@@ -10,10 +10,12 @@ import createViewModeButtons from './Main/createViewModeButtons';
 import createCroppingButtons from './Main/createCroppingButtons';
 import createResetCameraButton from './Main/createResetCameraButton';
 
-function createMainUI(rootContainer, store, use2D) {
-  const uiContainer = document.createElement('div');
+function createMainUI(rootContainer, store, use2D, uiContainer) {
+  if(!uiContainer){
+    uiContainer = document.createElement('div');
+    rootContainer.appendChild(uiContainer);
+  }
   store.mainUI.uiContainer = uiContainer;
-  rootContainer.appendChild(uiContainer);
   uiContainer.setAttribute('class', style.uiContainer);
 
   const mainUIGroup = document.createElement('div');

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -26,7 +26,9 @@ const createViewer = (
     use2D = false,
     rotate = true,
     viewerStyle,
-    viewerState }
+    viewerState,
+    uiContainer,
+   }
 ) => {
   UserInterface.emptyContainer(rootContainer);
 
@@ -60,6 +62,7 @@ const createViewer = (
     rootContainer,
     store,
     use2D,
+    uiContainer,
   );
 
   let updatingImage = false;
@@ -195,7 +198,7 @@ const createViewer = (
 
         UserInterface.createImageUI(
           store,
-          use2D
+          use2D,
         );
         const annotationContainer = store.container.querySelector('.js-se');
         annotationContainer.style.fontFamily = 'monospace';
@@ -401,6 +404,16 @@ const createViewer = (
   }
 
   const viewerDOMId = store.id;
+
+  // The `store` is considered an internal implementation detail 
+  // and its interface and behavior may change without changes to the major version.
+  publicAPI.getStore = () => {
+    return store;
+  }
+
+  publicAPI.getImage = () => {
+    return store.imageUI.image;
+  }
 
   const setImage = (image) => {
     store.imageUI.image = image;
@@ -959,6 +972,8 @@ const createViewer = (
     store.style.backgroundColor = bgColor;
   }
 
+  // The `itkVtkView` is considered an internal implementation detail 
+  // and its interface and behavior may change without changes to the major version.
   publicAPI.getViewProxy = () => {
     return store.itkVtkView;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-import getFileExtension from 'itk/getFileExtension'
+import getFileExtension from 'itk/getFileExtension';
 
 import fetchBinaryContent from './fetchBinaryContent';
-import processFiles from './processFiles';
+import { processFiles } from './processFiles';
 import UserInterface from './UserInterface';
 import createFileDragAndDrop from './UserInterface/createFileDragAndDrop';
 import style from './UserInterface/ItkVtkViewer.module.css';
@@ -11,11 +11,21 @@ import createViewer from './createViewer';
 
 let doNotInitViewers = false;
 
-export {default as createViewer} from './createViewer';
+export { default as createViewer } from './createViewer';
+import * as utils from './utils.js';
+export { utils };
+
+// The `UserInterface` is considered an internal implementation detail 
+// and its interface and behavior may change without changes to the major version.
+export { UserInterface };
 
 export function createViewerFromLocalFiles(container) {
   doNotInitViewers = true;
   createFileDragAndDrop(container, processFiles);
+}
+
+export async function createViewerFromFiles(el, files, use2D = false) {
+  return processFiles(el, { files: files, use2D });
 }
 
 export async function createViewerFromUrl(el, url, use2D = false) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,6 @@
+import vtkITKHelper from 'vtk.js/Sources/Common/DataModel/ITKHelper';
+import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+
+export { readFiles } from './processFiles';
+export { vtkITKHelper };
+export { vtkCoordinate };


### PR DESCRIPTION
Not sure how you would do this, but with this PR, I am trying to extract utility functions and export it such that it will be much easier to customize the viewer. 

For now, `itkVtkViewer.utils` has:
 * `readFiles` for reading files into VTK image
 * `convertItkToVtkImage` for converting user data into a VTK image
 *  `UserInterface` for customize the user interface, for example recreate the MainUI in another containier outside the viewer.

With these extracted functions and additions to existing api, I would like to:
1. be able to load a file object locally or fetched remotely with `utils.readFiles`
2. construct an ITK image for the veiwer with `convertItkToVtkImage`
3. create the MainUI in a custom container which will likely outside the root container of the viewer
4. be able to recreate the MainUI by passing the store object obtained from the added publicAPI function called `getStore`.


And I think we can add more in the future.

Please let me know if you have better idea.