### PR TITLE
Add css class for styling corner annotation

### DIFF
--- a/src/ItkVtkViewProxy.js
+++ b/src/ItkVtkViewProxy.js
@@ -10,7 +10,7 @@ import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
 const CursorCornerAnnotation =
-  '<table style="margin-left: 0;"><tr><td style="margin-left: auto; margin-right: 0;">Index:</td><td>${iIndex},</td><td>${jIndex},</td><td>${kIndex}</td></tr><tr><td style="margin-left: auto; margin-right: 0;">Position:</td><td>${xPosition},</td><td>${yPosition},</td><td>${zPosition}</td></tr><tr><td style="margin-left: auto; margin-right: 0;"">Value:</td><td>${value}</td></tr></table>';
+  '<table class="corner-annotation" style="margin-left: 0;"><tr><td style="margin-left: auto; margin-right: 0;">Index:</td><td>${iIndex},</td><td>${jIndex},</td><td>${kIndex}</td></tr><tr><td style="margin-left: auto; margin-right: 0;">Position:</td><td>${xPosition},</td><td>${yPosition},</td><td>${zPosition}</td></tr><tr><td style="margin-left: auto; margin-right: 0;"">Value:</td><td>${value}</td></tr></table>';
 
 const { vtkErrorMacro } = macro;
 


### PR DESCRIPTION
This PR aims to address https://github.com/Kitware/itk-vtk-viewer/issues/240 by adding a class to the corner annotation such that a developer can do something like:
```css
.corner-annotation {
  font-size: 2rem;
  color: gray;
}
```
to customize the corner annotation.