### PR TITLE
fix(Viewer): Make piecewise function cover max

### DIFF
--- a/src/UserInterface/Image/createTransferFunctionWidget.js
+++ b/src/UserInterface/Image/createTransferFunctionWidget.js
@@ -208,7 +208,7 @@ function createTransferFunctionWidget(store, uiContainer, use2D) {
           ])
         } else {
           store.imageUI.opacityGaussians.push([
-            { position: 0.5, height: 1.0, width: 0.5, xBias: 0.5, yBias: 0.4 },
+            { position: 0.5, height: 1.0, width: 0.5, xBias: 0.51, yBias: 0.4 },
           ])
         }
       }


### PR DESCRIPTION
By adjusting the default `xBias` used to initialize the piecewise functions, we can make sure the function does not drop to near zero at the max end of the data range.

Fixes #246 