### PR TITLE
WIP: Replace lut pwf select with tabs

### DIFF
--- a/src/CoordDecompressor.js
+++ b/src/CoordDecompressor.js
@@ -9,12 +9,16 @@ class CoordDecompressor {
   }
 
   async getCoord() {
-    const response = await axios.get(this.chunkUrl, { responseType: 'arraybuffer' })
+    const response = await axios.get(this.chunkUrl, {
+      responseType: 'arraybuffer',
+    })
     const compressedChunk = response.data
-    const chunk = await bloscZarrDecompress(compressedChunk, this.zarrayMetadata)
+    const chunk = await bloscZarrDecompress(
+      compressedChunk,
+      this.zarrayMetadata
+    )
     return chunk
   }
 }
-
 
 export default CoordDecompressor

--- a/src/Rendering/index.js
+++ b/src/Rendering/index.js
@@ -1,0 +1,8 @@
+import updateSliceProperties from './updateSliceProperties'
+import updateVolumeProperties from './updateVolumeProperties'
+
+
+export default {
+    updateSliceProperties,
+    updateVolumeProperties,
+}

--- a/src/Rendering/updateSliceProperties.js
+++ b/src/Rendering/updateSliceProperties.js
@@ -1,0 +1,21 @@
+
+function updateSliceProperties(store) {
+  const numberOfComponents = store.imageUI.numberOfComponents
+  if (!!store.imageUI.representationProxy) {
+    const sliceActors = store.imageUI.representationProxy.getActors()
+    sliceActors.forEach(actor => {
+      const actorProp = actor.getProperty();
+      actorProp.setIndependentComponents(true);
+      for (let component = 0; component < numberOfComponents; component++) {
+        const lutProxy = store.imageUI.lookupTableProxies[component];
+        const pwfProxy = store.imageUI.piecewiseFunctionProxies[component];
+        const visibility = store.imageUI.componentVisibilities[component];
+        actorProp.setRGBTransferFunction(component, lutProxy.getLookupTable());
+        actorProp.setPiecewiseFunction(component, pwfProxy.getPiecewiseFunction());
+        actorProp.setComponentWeight(component, visibility);
+      }
+    })
+  }
+}
+
+export default updateSliceProperties

--- a/src/Rendering/updateVolumeProperties.js
+++ b/src/Rendering/updateVolumeProperties.js
@@ -1,0 +1,24 @@
+
+function updateVolumeProperties(store) {
+  const numberOfComponents = store.imageUI.numberOfComponents
+  if (!!store.imageUI.representationProxy) {
+    const volumeProps = store.imageUI.representationProxy.getVolumes()
+    volumeProps.forEach(volume => {
+      const volumeProperty = volume.getProperty()
+      for (let component = 0; component < numberOfComponents; component++) {
+        const lut = store.imageUI.lookupTableProxies[
+          component
+        ].getLookupTable()
+        const piecewiseFunction = store.imageUI.piecewiseFunctionProxies[
+          component
+        ].getPiecewiseFunction()
+        const visibility = store.imageUI.componentVisibilities[component]
+        volumeProperty.setRGBTransferFunction(component, lut)
+        volumeProperty.setScalarOpacity(component, piecewiseFunction)
+        volumeProperty.setComponentWeight(component, visibility)
+      }
+    })
+  }
+}
+
+export default updateVolumeProperties

--- a/src/UserInterface/Image/createComponentSelector.js
+++ b/src/UserInterface/Image/createComponentSelector.js
@@ -1,16 +1,21 @@
 import { reaction, action } from 'mobx'
 
+import updateSliceProperties from '../../Rendering/updateSliceProperties'
+import updateVolumeProperties from '../../Rendering/updateVolumeProperties'
 import style from '../ItkVtkViewer.module.css'
 
 function createComponentSelector(store, imageUIGroup) {
   const viewerDOMId = store.id
 
-  const componentSelector = document.createElement('select')
+  const componentSelector = document.createElement('div')
   componentSelector.setAttribute('class', style.selector)
   componentSelector.id = `${viewerDOMId}-componentSelector`
 
   const componentRow = document.createElement('div')
   componentRow.setAttribute('class', style.uiRow)
+  // This row needs custom bottom padding, to aid in the illusion
+  // that it's the tabbed portion of a tabbed pane
+  componentRow.setAttribute('style', 'padding-bottom: 0px;')
   componentRow.className += ` ${viewerDOMId}-volumeComponents ${viewerDOMId}-toggle`
 
   function updateAvailableComponents() {
@@ -25,8 +30,20 @@ function createComponentSelector(store, imageUIGroup) {
       .fill(undefined)
       .map((_, ii) => ii)
       .map(
-        component =>
-          `<option value="${component}" >Component ${component}</option>`
+        (idx, component) =>
+          `<input name="tabs" type="radio" id="tab-${component}" ${
+            idx === 0 ? 'checked="checked"' : ''
+          } class="${
+            style.componentTab
+          }" data-component-index="${component}"/><label for="tab-${component}" class="${
+            style.compTabLabel
+          }">${component}<input type="checkbox" ${
+            store.imageUI.componentVisibilities[idx] > 0.0
+              ? 'checked="checked"'
+              : ''
+          } class="${
+            style.componentVisibility
+          }" data-component-index="${component}"\></label>`
       )
       .join('')
     componentSelector.value = 0
@@ -47,16 +64,27 @@ function createComponentSelector(store, imageUIGroup) {
     action(event => {
       event.preventDefault()
       event.stopPropagation()
-      store.imageUI.selectedComponentIndex = Number(event.target.value)
+      const selIdx = Number(event.target.dataset.componentIndex)
+      if (event.target.type === 'radio') {
+        store.imageUI.selectedComponentIndex = selIdx
+      } else if (event.target.type === 'checkbox') {
+        const visibility = event.target.checked ? 1.0 : 0.0
+        store.imageUI.componentVisibilities[selIdx] = visibility
+      }
     })
   )
 
   reaction(
     () => {
-      return store.imageUI.selectedComponentIndex
+      return store.imageUI.componentVisibilities.slice()
     },
-    componentIndex => {
-      componentSelector.value = componentIndex
+    visibilities => {
+      updateSliceProperties(store)
+      updateVolumeProperties(store)
+      const renderWindow = store.renderWindow
+      if (!renderWindow.getInteractor().isAnimating()) {
+        renderWindow.render()
+      }
     }
   )
 

--- a/src/UserInterface/Image/createTransferFunctionWidget.js
+++ b/src/UserInterface/Image/createTransferFunctionWidget.js
@@ -239,6 +239,12 @@ function createTransferFunctionWidget(store, uiContainer, use2D) {
 
   const transferFunctionWidgetRow = document.createElement('div')
   transferFunctionWidgetRow.setAttribute('class', style.uiRow)
+  // This row needs background different from normal uiRows, to aid
+  // in the illusion that it's the content portion of a tabbed pane
+  transferFunctionWidgetRow.setAttribute(
+    'style',
+    'background: rgba(127, 127, 127, 0.5);'
+  )
   transferFunctionWidgetRow.className += ` ${store.id}-toggle`
   transferFunctionWidgetRow.appendChild(piecewiseWidgetContainer)
   uiContainer.appendChild(transferFunctionWidgetRow)

--- a/src/UserInterface/ItkVtkViewer.module.css
+++ b/src/UserInterface/ItkVtkViewer.module.css
@@ -43,7 +43,7 @@
   flex: 1;
   align-items: center;
   justify-content: space-between;
-  padding: 2px;
+  padding: 5px;
 }
 
 .mainUIRow {
@@ -443,13 +443,39 @@ input:checked.toggleInput + label {
 }
 
 .selector {
-  flex: 1;
-  border: none;
-  background: transparent;
-  color: white;
-  border: none;
+  display: flex;
+  direction: row;
   font-size: 1.2em;
   z-index: 1000;
+}
+
+.componentTab {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.componentTab + .compTabLabel {
+  background: rgba(40, 40, 40, 0.5);
+  padding: 5px;
+  margin-right: 2px;
+  border-radius: 5px 5px 0px 0px;
+  color: #777;
+}
+
+.componentTab:hover + .compTabLabel {
+  background: rgba(90, 90, 90, 0.5);
+}
+
+.componentTab:checked + .compTabLabel {
+  background: rgba(127, 127, 127, 0.5);
+  color: #FFF;
+}
+
+.componentVisibility {
+  position: relative;
+  top: -2px;
+  margin-left: 10px;
 }
 
 select {

--- a/src/UserInterface/createImageUI.js
+++ b/src/UserInterface/createImageUI.js
@@ -37,6 +37,9 @@ function createImageUI(store, use2D) {
     ) {
       const colorRangeInputRow = document.createElement('div')
       colorRangeInputRow.setAttribute('class', style.uiRow)
+      // This row needs background different from normal uiRows, to aid
+      // in the illusion that it's the content portion of a tabbed pane
+      colorRangeInputRow.setAttribute('style', 'background: rgba(127, 127, 127, 0.5);')
       createColorRangeInput(store, colorRangeInputRow)
       colorRangeInputRow.className += ` ${viewerDOMId}-toggle`
       imageUIGroup.appendChild(colorRangeInputRow)

--- a/src/ViewerStore.js
+++ b/src/ViewerStore.js
@@ -55,6 +55,7 @@ class ImageUIStore {
 
   lookupTableProxies = []
   piecewiseFunctionProxies = []
+  @observable componentVisibilities = []
   transferFunctionWidget = null
 
   croppingWidget = null

--- a/src/bloscZarrDecompress.js
+++ b/src/bloscZarrDecompress.js
@@ -40,11 +40,11 @@ async function bloscZarrDecompress(compressed, zarrayMetadata) {
     },
   ]
   //const { stdout, stderr, outputs, webWorker } = await runPipelineBrowser(
-    //null,
-    //'BloscZarr',
-    //args,
-    //desiredOutputs,
-    //inputs
+  //null,
+  //'BloscZarr',
+  //args,
+  //desiredOutputs,
+  //inputs
   //)
   //webWorker.terminate()
   let stdout = null

--- a/src/processFiles.js
+++ b/src/processFiles.js
@@ -136,6 +136,7 @@ export const readFiles = ({ files, use2D }) => {
               webWorker.terminate()
               const is3D = itkImage.imageType.dimension === 3 && !use2D
               const imageData = vtkITKHelper.convertItkToVtkImage(itkImage)
+              console.log('Resolving image data promise (readImageFile)')
               return Promise.resolve({ is3D, data: imageData })
             })
             .catch(error => {


### PR DESCRIPTION
This is coming along.  Still needed:

- [x] Better styling of tabs
- [x] text of labels better contrast
- [x] Improve look/feel of visibility checkboxes
- [x] Hook up component visibility to volume rendering
- [ ] with 2 components, second one doesn't seem to be registered until you click the tab
- [x] if only one component, don't show the tabs (and don't allow turning that comp off)