### PR TITLE
fix(createGeometryOpacitySlider): apply default geometry opacity

### DIFF
--- a/src/UserInterface/Geometries/createGeometryOpacitySlider.js
+++ b/src/UserInterface/Geometries/createGeometryOpacitySlider.js
@@ -51,19 +51,19 @@ function createGeometryOpacitySlider(store, geometryColorRow) {
     }
   )
 
-  reaction(
-    () => {
-      return store.geometriesUI.opacities.slice()
-    },
-    opacities => {
-      opacities.forEach((opacity, index) => {
-        store.geometriesUI.representationProxies[index].setOpacity(opacity)
+  function applyOpacities(opacities) {
+    opacities.forEach((opacity, index) => {
+             store.geometriesUI.representationProxies[index].setOpacity(opacity)
       })
-      store.renderWindow.render()
-      const selectedGeometryIndex = store.geometriesUI.selectedGeometryIndex
-      opacityElement.value = opacities[selectedGeometryIndex]
-    }
-  )
+
+    store.renderWindow.render() 
+    const selectedGeometryIndex = store.geometriesUI.selectedGeometryIndex
+    opacityElement.value = opacities[selectedGeometryIndex]
+  }
+
+  reaction(() => {
+     return store.geometriesUI.opacities.slice() 
+   }, applyOpacities)
 
   opacityElement.addEventListener(
     'input',
@@ -83,8 +83,9 @@ function createGeometryOpacitySlider(store, geometryColorRow) {
   defaultGeometryOpacities.fill(defaultGeometryOpacity)
   opacityElement.value = defaultGeometryOpacity
   store.geometriesUI.opacities = defaultGeometryOpacities
+  applyOpacities(store.geometriesUI.opacities)
 
   geometryColorRow.appendChild(sliderEntry)
-}
+  }
 
 export default createGeometryOpacitySlider


### PR DESCRIPTION
As suggested by @thewtex in PR #270, I apply the same changes to handle the opacity default value. I let the default value to 1.0 since it is perhaps more std in the general use. But changing the default value make well change the first opacity. I tested here: http://ipol-geometry.loria.fr/~kerautre/ipol_demo/LiverVesselnessIPOLDemo/result?key=E06650B089BFFDD6C31AC33C901556E8