### PR TITLE
Fix issue affecting labemaps with many labels

### DIFF
--- a/src/Rendering/createLabelMapRendering.js
+++ b/src/Rendering/createLabelMapRendering.js
@@ -2,6 +2,15 @@ import vtkLookupTableProxy from 'vtk.js/Sources/Proxy/Core/LookupTableProxy'
 import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction'
 import applyCategoricalColorToLookupTableProxy from './../UserInterface/applyCategoricalColorToLookupTableProxy'
 
+function numericalSort(eltA, eltB) {
+  if (eltA < eltB) {
+    return -1
+  } else if (eltB < eltA) {
+    return 1
+  }
+  return 0
+}
+
 function createLabelMapRendering(store) {
   const numberOfComponents = store.imageUI.numberOfComponents
 
@@ -16,7 +25,7 @@ function createLabelMapRendering(store) {
   // The volume mapper currently only supports ColorTransferFunction's,
   // not LookupTable's
   // lut.setAnnotations(uniqueLabels, uniqueLabels);
-  uniqueLabels.sort()
+  uniqueLabels.sort(numericalSort)
   store.imageUI.labelMapLabels = uniqueLabels
 
   applyCategoricalColorToLookupTableProxy(

--- a/src/UserInterface/Main/createInterpolationButton.js
+++ b/src/UserInterface/Main/createInterpolationButton.js
@@ -1,4 +1,4 @@
-import { when, autorun } from 'mobx'
+import { when, autorun, reaction } from 'mobx'
 
 import style from '../ItkVtkViewer.module.css'
 
@@ -35,6 +35,20 @@ function createInterpolationButton(store, mainUIRow) {
   autorun(() => {
     toggleInterpolation()
   })
+  reaction(
+    () => store.imageUI.labelMap,
+    () => {
+      const inputElt = interpolationButton.getElementsByTagName('input')[0]
+      if (!!store.imageUI.labelMap) {
+        store.mainUI.interpolationEnabled = false
+        inputElt.checked = false
+        inputElt.disabled = true
+      } else {
+        inputElt.disabled = false
+      }
+      toggleInterpolation()
+    }
+  )
   interpolationButton.addEventListener('change', event => {
     event.preventDefault()
     event.stopPropagation()


### PR DESCRIPTION
This PR fixes the regression with the interpolation button being enabled, even when we we have a labelmap, as well as some issues we saw last week with lots of labels seemingly getting assigned the same color, even though mouse picking could distinguish the labeled regions.

![fix-issue-with-many-labels-opt](https://user-images.githubusercontent.com/6527504/81006088-2a616880-8e0c-11ea-9010-8120aaba3d85.gif)


