### PR TITLE
WIP: Fixes for many component images

### DIFF
--- a/src/Rendering/updateGradientOpacity.js
+++ b/src/Rendering/updateGradientOpacity.js
@@ -1,40 +1,40 @@
 function updateGradientOpacity(store) {
   const gradientOpacity = store.imageUI.gradientOpacity
   const dataArray = store.imageUI.representationProxy.getDataArray()
-  const numberOfComponents = store.imageUI.numberOfComponents
+  const visualizedComponents = store.imageUI.visualizedComponents
   const volume = store.imageUI.representationProxy.getVolumes()[0]
   if (gradientOpacity === 0) {
-    for (let component = 0; component < numberOfComponents; component++) {
-      volume.getProperty().setUseGradientOpacity(component, false)
-    }
+    visualizedComponents.forEach((componentIdx, fusedImgIdx) => {
+      volume.getProperty().setUseGradientOpacity(fusedImgIdx, false)
+    })
   } else {
-    for (let component = 0; component < numberOfComponents; component++) {
-      const dataRange = dataArray.getRange(component)
-      volume.getProperty().setUseGradientOpacity(component, true)
+    visualizedComponents.forEach((componentIdx, fusedImgIdx) => {
+      const dataRange = dataArray.getRange(componentIdx)
+      volume.getProperty().setUseGradientOpacity(fusedImgIdx, true)
       const minV = Math.max(0.0, gradientOpacity - 0.3) / 0.7
       if (minV > 0.0) {
         volume
           .getProperty()
           .setGradientOpacityMinimumValue(
-            component,
+            fusedImgIdx,
             Math.exp(
               Math.log((dataRange[1] - dataRange[0]) * 0.2) * minV * minV
             )
           )
       } else {
-        volume.getProperty().setGradientOpacityMinimumValue(component, 0.0)
+        volume.getProperty().setGradientOpacityMinimumValue(fusedImgIdx, 0.0)
       }
       volume
         .getProperty()
         .setGradientOpacityMaximumValue(
-          component,
+          fusedImgIdx,
           Math.exp(
             Math.log((dataRange[1] - dataRange[0]) * 1.0) *
               gradientOpacity *
               gradientOpacity
           )
         )
-    }
+    })
   }
   store.renderWindow.render()
 }

--- a/src/Rendering/updateLabelMapComponentWeight.js
+++ b/src/Rendering/updateLabelMapComponentWeight.js
@@ -8,15 +8,18 @@ function updateLabelMapComponentWeight(store) {
   const sliceActor = store.imageUI.representationProxy.getActors()[0]
   const sliceProperty = sliceActor.getProperty()
   const numberOfComponents = store.imageUI.numberOfComponents
+  const visualizedComponents = store.imageUI.visualizedComponents
   const componentVisibilities = store.imageUI.componentVisibilities
-  for (let c = 0; c < numberOfComponents; c++) {
-    const componentVisibility = componentVisibilities[c]
+
+  visualizedComponents.forEach((componentIdx, fusedImgIdx) => {
+    const componentVisibility = componentVisibilities[componentIdx]
     componentVisibility.weight = 1.0 - labelMapBlend
     if (componentVisibility.visible) {
-      volumeProperty.setComponentWeight(c, componentVisibility.weight)
-      sliceProperty.setComponentWeight(c, componentVisibility.weight)
+      volumeProperty.setComponentWeight(fusedImgIdx, componentVisibility.weight)
+      sliceProperty.setComponentWeight(fusedImgIdx, componentVisibility.weight)
     }
-  }
+  })
+
   volumeProperty.setComponentWeight(numberOfComponents, labelMapBlend)
   sliceProperty.setComponentWeight(numberOfComponents, labelMapBlend)
 }

--- a/src/Rendering/updateSliceProperties.js
+++ b/src/Rendering/updateSliceProperties.js
@@ -1,27 +1,27 @@
 function updateSliceProperties(store) {
-  const numberOfComponents = store.imageUI.numberOfComponents
+  const visualizedComponents = store.imageUI.visualizedComponents
   const independentComponents = store.imageUI.independentComponents
   if (!!store.imageUI.representationProxy) {
     const sliceActors = store.imageUI.representationProxy.getActors()
-    sliceActors.forEach(actor => {
+    sliceActors.forEach((actor, actorIdx) => {
       const actorProp = actor.getProperty()
       actorProp.setIndependentComponents(independentComponents)
-      for (let component = 0; component < numberOfComponents; component++) {
-        const lutProxy = store.imageUI.lookupTableProxies[component]
-        const pwfProxy = store.imageUI.piecewiseFunctionProxies[component].slice
-        actorProp.setRGBTransferFunction(component, lutProxy.getLookupTable())
+      visualizedComponents.forEach((componentIdx, fusedImgIdx) => {
+        const lutProxy = store.imageUI.lookupTableProxies[componentIdx]
+        const pwfProxy = store.imageUI.piecewiseFunctionProxies[componentIdx].slice
+        actorProp.setRGBTransferFunction(fusedImgIdx, lutProxy.getLookupTable())
         actorProp.setPiecewiseFunction(
-          component,
+          fusedImgIdx,
           pwfProxy.getPiecewiseFunction()
         )
         const componentVisibility =
-          store.imageUI.componentVisibilities[component]
+          store.imageUI.componentVisibilities[componentIdx]
         if (componentVisibility.visible) {
-          actorProp.setComponentWeight(component, componentVisibility.weight)
+          actorProp.setComponentWeight(fusedImgIdx, componentVisibility.weight)
         } else {
-          actorProp.setComponentWeight(component, 0.0)
+          actorProp.setComponentWeight(fusedImgIdx, 0.0)
         }
-      }
+      })
     })
   }
 }

--- a/src/UserInterface/Image/createColorRangeInput.js
+++ b/src/UserInterface/Image/createColorRangeInput.js
@@ -17,8 +17,10 @@ function createColorRangeInput(store, uiContainer) {
   maximumInput.setAttribute('class', style.numberInput)
 
   function updateColorRangeInput() {
-    const dataArray = store.imageUI.image.getPointData().getScalars()
-    const numberOfComponents = store.imageUI.numberOfComponents
+    const dataArray = store.imageUI.fusedImageLabelMap
+      .getPointData()
+      .getScalars()
+    const numberOfComponents = store.imageUI.totalIntensityComponents
     for (let component = 0; component < numberOfComponents; component++) {
       const range = dataArray.getRange(component)
       minimumInput.min = range[0]

--- a/src/UserInterface/Image/createTransferFunctionWidget.js
+++ b/src/UserInterface/Image/createTransferFunctionWidget.js
@@ -45,7 +45,7 @@ function createTransferFunctionWidget(store, uiContainer, use2D) {
   })
   const dataArray = store.imageUI.image.getPointData().getScalars()
   transferFunctionWidget.setDataArray(dataArray.getData(), {
-    numberOfComponents: store.imageUI.numberOfComponents,
+    numberOfComponents: store.imageUI.totalIntensityComponents,
     component: store.imageUI.selectedComponentIndex,
   })
 
@@ -164,7 +164,7 @@ function createTransferFunctionWidget(store, uiContainer, use2D) {
   )
 
   function setupOpacityGaussians() {
-    const numberOfComponents = store.imageUI.numberOfComponents
+    const numberOfComponents = store.imageUI.totalIntensityComponents
     const gaussians = []
     for (let component = 0; component < numberOfComponents; component++) {
       if (store.imageUI.opacityGaussians.length > component) {

--- a/src/UserInterface/Image/updateTransferFunctionHistogramValues.js
+++ b/src/UserInterface/Image/updateTransferFunctionHistogramValues.js
@@ -3,7 +3,7 @@ function updateTransferFunctionHistogramValues(store, index) {
     return
   }
   const colorRange = store.imageUI.colorRanges[index]
-  const numberOfComponents = store.imageUI.numberOfComponents
+  const numberOfComponents = store.imageUI.totalIntensityComponents
   const transferFunctionWidget = store.imageUI.transferFunctionWidget
   const dataArray = store.imageUI.image.getPointData().getScalars()
   transferFunctionWidget.setDataArray(dataArray.getData(), {

--- a/src/UserInterface/Image/updateTransferFunctionWidget.js
+++ b/src/UserInterface/Image/updateTransferFunctionWidget.js
@@ -9,10 +9,10 @@ function doUpdates(store, widget, component) {
 }
 
 function updateTransferFunctionWidget(store) {
-  const numberOfComponents = store.imageUI.numberOfComponents
+  const totalComponents = store.imageUI.totalIntensityComponents
   const transferFunctionWidget = store.imageUI.transferFunctionWidget
   const selIdx = store.imageUI.selectedComponentIndex
-  for (let component = 0; component < numberOfComponents; component++) {
+  for (let component = 0; component < totalComponents; component++) {
     if (component !== selIdx) {
       doUpdates(store, transferFunctionWidget, component)
     }

--- a/src/UserInterface/ItkVtkViewer.module.css
+++ b/src/UserInterface/ItkVtkViewer.module.css
@@ -496,6 +496,11 @@ input:checked.toggleInput + label {
   pointer-events: none;
 }
 
+.componentDisabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 .componentTab + .compTabLabel {
   background: rgba(40, 40, 40, 0.5);
   padding: 5px;

--- a/src/UserInterface/createImageUI.js
+++ b/src/UserInterface/createImageUI.js
@@ -24,7 +24,9 @@ function createImageUI(store, use2D) {
   const haveImage = !!store.imageUI.image
 
   if (haveImage) {
-    const dataArray = store.imageUI.image.getPointData().getScalars()
+    const dataArray = store.imageUI.fusedImageLabelMap
+      .getPointData()
+      .getScalars()
     const components = store.imageUI.numberOfComponents
 
     // If not a 2D RGB image

--- a/src/ViewerStore.js
+++ b/src/ViewerStore.js
@@ -1,4 +1,4 @@
-import { observable, computed } from 'mobx'
+import { observable, computed, trace } from 'mobx'
 import EventEmitter from 'eventemitter3'
 
 import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData'
@@ -70,6 +70,8 @@ class ImageUIStore {
   lookupTableProxies = []
   piecewiseFunctionProxies = []
   @observable componentVisibilities = []
+  lastVisualizedComponents = []
+  fusedImageData = null
   @observable visualizedComponents = []
   lastComponentVisibilityChanged = 0
   transferFunctionWidget = null
@@ -108,10 +110,6 @@ class ImageUIStore {
   // @observable fusingImages = false
 
   @computed get fusedImageLabelMap() {
-    console.log(
-      ' --------------------------------- AGAIN -------------------------------- '
-    )
-
     const image = this.image
     const labelMap = this.labelMap
 
@@ -138,8 +136,7 @@ class ImageUIStore {
       return image
     }
 
-    const visualizedComponents = this.visualizedComponents
-    const numVizComponents = visualizedComponents.length
+    const visualizedComponents = this.visualizedComponents.map(idx => idx)
 
     const fusedImage = vtkImageData.newInstance()
     fusedImage.setOrigin(image.getOrigin())
@@ -172,6 +169,7 @@ class ImageUIStore {
     if (!!labelMap) {
       labelMapScalars = labelMap.getPointData().getScalars()
       labelMapData = labelMapScalars.getData()
+      visualizedComponents.push(-1)
     }
 
     const fusedImageComponents = labelMapData
@@ -179,29 +177,66 @@ class ImageUIStore {
       : numVisualizedComponents
 
     const length = imageTuples * fusedImageComponents
-    const fusedImageData = new imageData.constructor(length)
+
+    // We only need to construct a new typed array if we don't already
+    // have one of the right length.
+    if (!!!this.fusedImageData || this.fusedImageData.length !== length) {
+      this.fusedImageData = new imageData.constructor(length)
+    }
+
+    const copyStructure = []
+
+    // Loop through comparing to last time and check which components need
+    // to be copied into fusedImageData.  This loop doesn't include the
+    // labelmap componentm, it will be checked next.
+    for (let i = 0; i < numVisualizedComponents; i++) {
+      if (visualizedComponents[i] !== this.lastVisualizedComponents[i]) {
+        copyStructure.push({
+          srcImageData: imageData,
+          imageComponents: imageComponents,
+          copyFromComponent: this.visualizedComponents[i],
+          copyToComponent: i,
+        })
+      }
+    }
+
+    // Check if we need to re-copy the labelmap component
+    if (
+      visualizedComponents[numVisualizedComponents] === -1 &&
+      this.lastVisualizedComponents[numVisualizedComponents] !== -1
+    ) {
+      copyStructure.push({
+        srcImageData: labelMapData,
+        imageComponents: 1,
+        copyFromComponent: 0,
+        copyToComponent: numVisualizedComponents,
+      })
+    }
+
+    // console.log(`Copying ${copyStructure.length} components into fused image`)
 
     let fusedIndex = 0
     let imageIndex = 0
-    let labelMapIndex = 0
     for (let tuple = 0; tuple < imageTuples; tuple++) {
-      for (let component = 0; component < numVizComponents; component++) {
-        imageIndex = tuple * imageComponents + visualizedComponents[component]
-        fusedImageData[fusedIndex++] = imageData[imageIndex]
-      }
-      if (labelMapData) {
-        fusedImageData[fusedIndex++] = labelMapData[labelMapIndex++]
+      for (let cIdx = 0; cIdx < copyStructure.length; cIdx++) {
+        imageIndex =
+          tuple * copyStructure[cIdx].imageComponents +
+          copyStructure[cIdx].copyFromComponent
+        fusedIndex =
+          tuple * fusedImageComponents + copyStructure[cIdx].copyToComponent
+        this.fusedImageData[fusedIndex] =
+          copyStructure[cIdx].srcImageData[imageIndex]
       }
     }
 
     const fusedImageScalars = vtkDataArray.newInstance({
       name: imageScalars.getName() || 'Scalars',
-      values: fusedImageData,
+      values: this.fusedImageData,
       numberOfComponents: fusedImageComponents,
     })
 
     fusedImage.getPointData().setScalars(fusedImageScalars)
-
+    this.lastVisualizedComponents = visualizedComponents.map(idx => idx)
     return fusedImage
   }
 

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -187,10 +187,14 @@ const createViewer = (
 
         if (transferFunctionWidget) {
           transferFunctionWidget.setDataArray(
-            fusedImage
+            store.imageUI.image
               .getPointData()
               .getScalars()
-              .getData()
+              .getData(),
+            {
+              numberOfComponents: store.imageUI.totalIntensityComponents,
+              component: store.imageUI.selectedComponentIndex,
+            }
           )
           transferFunctionWidget.invokeOpacityChange(transferFunctionWidget)
           transferFunctionWidget.modified()


### PR DESCRIPTION
Add support for when images have more components that we can visualize at one time.

This is getting close, some remaining items:

- [ ] need to recompute the max gradient opacity value each time we re-fuse image
- [ ] When we hit a checkbox and we have to re-fuse the images, the lighting is turned back on but the checkbox isn't kept in sync
- [ ] Show component names if available (add a store datastructure, a way to populate it, and a way to load data for it into application)
- [ ] Every time the `fusedImage` changes, we go back through `createImageRendering` again, which trashes and recreates the lookup table and piecewise function proxies, and picks new default presets.  This causes us to lose any changes to colormaps we have made.  The gaussians are also changed from what we may have set, but they're not back to the initial defaults.  If I'm looking at a transfer function on a component where I picked a new colormap, then I also see a mismatch between what's drawn on top of the histogram and what's in the color selector (color selector has the replaced color, the original default, while on top of the histogram I see the new colormap I had picked but which got replaced).  I just need to look at a different one, and then come back to see the state sync'd up again.
- [ ] (Needs validation) When we have a component hidden, but it's not the most recently touched component (call this guy "unlucky"), when we show another component that requires re-fusing, then suddenly "unlucky" will be shown instead of hidden, even though I didn't click it's checkbox.
- [ ] (Needs validation) I sometimes see that old bug (after replacing a component) where the render view changes just from clicking on a different component tab
- [ ] Generally needs to be exercised with a lot of different datasets to try and find any other issues.