### PR TITLE
fix(updateLabelMapComponentWeight): Update only when label map present

### DIFF
--- a/src/Rendering/updateLabelMapComponentWeight.js
+++ b/src/Rendering/updateLabelMapComponentWeight.js
@@ -1,4 +1,7 @@
 function updateLabelMapComponentWeight(store) {
+  if (!store.imageUI.haveLabelMap) {
+    return
+  }
   const labelMapOpacity = store.imageUI.labelMapOpacity
   const volume = store.imageUI.representationProxy.getVolumes()[0]
   const volumeProperty = volume.getProperty()

--- a/src/ViewerStore.js
+++ b/src/ViewerStore.js
@@ -148,6 +148,9 @@ class ImageUIStore {
       !!!this.multiscaleImage
     )
   }
+  @computed get haveLabelMap() {
+    return !!this.labelMap || !!this.multiscaleLabelMap
+  }
 
   labelMapColorUIGroup = null
   labelMapLookupTableProxy = null


### PR DESCRIPTION
When a label map is not present, avoid falsely suppressing the intensity
image.