### PR TITLE
fix(Geometries): Support direct unsigned char scalar colors

### DIFF
--- a/src/UserInterface/Geometries/createGeometryColorBySelector.js
+++ b/src/UserInterface/Geometries/createGeometryColorBySelector.js
@@ -108,6 +108,7 @@ function createGeometryColorBySelector(store, colorByRow) {
       const interpolateScalarsBeforeMapping = location === 'pointData'
       proxy.setInterpolateScalarsBeforeMapping(interpolateScalarsBeforeMapping)
       proxy.setColorBy(colorByArrayName, location)
+      proxy.getMapper().setColorModeToDefault()
       store.renderWindow.render()
 
       const hasScalars = store.geometriesUI.hasScalars
@@ -140,6 +141,7 @@ function createGeometryColorBySelector(store, colorByRow) {
       const interpolateScalarsBeforeMapping = location === 'pointData'
       proxy.setInterpolateScalarsBeforeMapping(interpolateScalarsBeforeMapping)
       proxy.setColorBy(colorByArrayName, location)
+      proxy.getMapper().setColorModeToDefault()
     }
   })
   const selectedGeometryIndex = store.geometriesUI.selectedGeometryIndex

--- a/src/UserInterface/Geometries/createGeometryColorRangeInput.js
+++ b/src/UserInterface/Geometries/createGeometryColorRangeInput.js
@@ -17,7 +17,7 @@ function createColorRangeInput(store, uiContainer) {
 
   function updateColorRangeInput() {
     const selectedIndex = store.geometriesUI.selectedGeometryIndex
-    if (!store.geometriesUI.hasScalars[selectedIndex]) {
+    if (store.geometriesUI.hasOnlyDirectColors[selectedIndex]) {
       return
     }
     const colorByKey = store.geometriesUI.colorBy[selectedIndex].value
@@ -203,7 +203,7 @@ function createColorRangeInput(store, uiContainer) {
 
   function updateColorCanvas() {
     const geometryIndex = store.geometriesUI.selectedGeometryIndex
-    if (!store.geometriesUI.hasScalars[geometryIndex]) {
+    if (store.geometriesUI.hasOnlyDirectColors[geometryIndex]) {
       return
     }
     const colorMap = store.geometriesUI.colorMaps[geometryIndex]
@@ -277,8 +277,8 @@ function createColorRangeInput(store, uiContainer) {
       return store.geometriesUI.selectedGeometryIndex
     },
     selectedIndex => {
-      const hasScalars = store.geometriesUI.hasScalars
-      if (hasScalars[selectedIndex]) {
+      const directColors = store.geometriesUI.hasOnlyDirectColors
+      if (directColors[selectedIndex]) {
         uiContainer.style.display = 'flex'
         updateColorRangeInput()
         updateColorCanvas()
@@ -298,9 +298,9 @@ function createColorRangeInput(store, uiContainer) {
   )
 
   updateColorCanvas()
-  const hasScalars = store.geometriesUI.hasScalars
+  const directColors = store.geometriesUI.hasOnlyDirectColors
   const selectedIndex = store.geometriesUI.selectedGeometryIndex
-  if (hasScalars[selectedIndex]) {
+  if (directColors[selectedIndex]) {
     uiContainer.style.display = 'flex'
   } else {
     uiContainer.style.display = 'none'

--- a/src/ViewerStore.js
+++ b/src/ViewerStore.js
@@ -3,6 +3,7 @@ import EventEmitter from 'eventemitter3'
 
 import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData'
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray'
+import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants'
 
 const STYLE_CONTAINER = {
   position: 'relative',
@@ -195,11 +196,26 @@ class GeometriesUIStore {
   colorRangesReactions = new Map()
   @computed get hasScalars() {
     return this.geometries.map(geometry => {
-      const pointData = geometry.getPointData()
-      const hasPointDataScalars = !!pointData.getScalars()
-      const cellData = geometry.getCellData()
-      const hasCellDataScalars = !!cellData.getScalars()
-      return hasPointDataScalars || hasCellDataScalars
+      const pointDataScalars = !!geometry.getPointData().getScalars()
+      const cellDataScalars = !!geometry.getCellData().getScalars()
+
+      return pointDataScalars || cellDataScalars
+    })
+  }
+  @computed get hasOnlyDirectColors() {
+    return this.geometries.map(geometry => {
+      const pointDataScalars = geometry.getPointData().getScalars()
+      const pointDataDirectColors =
+        !!pointDataScalars &&
+        pointDataScalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR &&
+        pointDataScalars.getNumberOfComponents() === 3
+      const cellDataScalars = geometry.getCellData().getScalars()
+      const cellDataDirectColors =
+        !!cellDataScalars &&
+        cellDataScalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR &&
+        cellDataScalars.getNumberOfComponents() === 3
+
+      return pointDataDirectColors && cellDataDirectColors
     })
   }
   @computed get colorByOptions() {


### PR DESCRIPTION
The vtk.js AbstractRepresentationProxy sets the Mapper ColorMode to
MAP_SCALARS if scalars and a lookup table proxy are present, but we always
have a lookup table proxy. Set ColorModeToDefault on the Mapper and high
lookup table GUI elements with 3-component unsigned char scalars.