### PR TITLE
fix(PiecewiseFunction): Bump vtk.js to 14.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23077,9 +23077,9 @@
       "dev": true
     },
     "vtk.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-14.7.1.tgz",
-      "integrity": "sha512-ihpOngAHF0yYirG+P8Y7SohTcwKWXIRuH7Un4jRe1PgLWxcd+t1uVXhuKadtONuaAGMn4sfhkTb4cR4MqoK+Ew==",
+      "version": "14.8.1",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-14.8.1.tgz",
+      "integrity": "sha512-RRS5qO9fCMCQD3a1l4/m6s2SXL6dmXjYpLiuTCkgkZUtQhJ38jdYvYtuUtm8wnUc0eWnJr6XFNB3bvsO2RuZfg==",
       "requires": {
         "blueimp-md5": "2.13.0",
         "commander": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "open": "^6.4.0",
     "promise-file-reader": "^1.0.2",
     "regenerator-runtime": "^0.13.5",
-    "vtk.js": "^14.7.1"
+    "vtk.js": "^14.8.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.6",


### PR DESCRIPTION
Adds https://github.com/Kitware/vtk-js/pull/1512 to address:

  https://github.com/Kitware/itk-vtk-viewer/issues/310

For single component images.