### PR TITLE
fix(colorRangesChangedEvent): Fix emission

### DIFF
--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -483,7 +483,7 @@ const createViewer = (
     'toggleCroppingPlanes',
     'croppingPlanesChanged',
     'resetCrop',
-    'changeColorRange',
+    'colorRangesChanged',
     'selectColorMap',
     'selectLookupTable',
     'viewModeChanged',
@@ -721,12 +721,7 @@ const createViewer = (
 
   autorun(() => {
     const colorRanges = store.imageUI.colorRanges
-    const selectedComponentIndex = store.imageUI.selectedComponentIndex
-    eventEmitter.emit(
-      'changeColorRange',
-      selectedComponentIndex,
-      colorRanges[selectedComponentIndex]
-    )
+    eventEmitter.emit('colorRangesChanged', colorRanges)
   })
 
   publicAPI.setColorRange = (componentIndex, colorRange) => {


### PR DESCRIPTION
This technically a breaking change, but this is required to:

- Use a consistent event name.
- Avoid emitting too often when the selected component index changes.
- mobx emits a warning during initialization when accessing an empty
value (how this was discovered).