### PR TITLE
feat(ImJoy): Support image URL and File

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -78,23 +78,45 @@
         },
 
         async setImage(image) {
-          let itkImage = image
-          if(image._rtype === 'ndarray'){
-            itkImage = itkVtkViewer.utils.ndarrayToItkImage(image)
+          // load image from an URL
+          if(typeof image === 'string'){
+            this.viewer = await itkVtkViewer.processURLParameters(container, {image})
           }
-
-          const vtkImage = itkVtkViewer.utils.vtkITKHelper.convertItkToVtkImage(itkImage)
-          const is2D = itkImage.imageType.dimension === 2
-          if (this.viewer === null) {
-            this.viewer = await itkVtkViewer.createViewer(container, {
-              image: vtkImage,
-              pointSets: null,
-              geometries: null,
-              use2D: is2D,
-              rotate: false
-            })
-          } else {
-            await this.viewer.setImage(vtkImage)
+          // load image from a File object
+          else if(image instanceof File){
+            this.viewer = await itkVtkViewer.createViewerFromFiles(container, [image])
+          }
+          // load image from a list of file URL or files
+          else if(Array.isArray(image)){
+            if(typeof image[0] === 'string') {
+              this.viewer = await itkVtkViewer.processURLParameters(container, {filesToLoad: image.join(",")})
+            }
+            else if(image[0] instanceof File){
+              this.viewer = await itkVtkViewer.createViewerFromFiles(container, image)
+            }
+          }
+          // load image from an ndarray or itkimage
+          else if(image._rtype === 'ndarray' || (image.imageType && image.data)){
+            let itkImage = image
+            if(image._rtype === 'ndarray'){
+              itkImage = itkVtkViewer.utils.ndarrayToItkImage(image)
+            }
+            const vtkImage = itkVtkViewer.utils.vtkITKHelper.convertItkToVtkImage(itkImage)
+            const is2D = itkImage.imageType.dimension === 2
+            if (this.viewer === null) {
+              this.viewer = await itkVtkViewer.createViewer(container, {
+                image: vtkImage,
+                pointSets: null,
+                geometries: null,
+                use2D: is2D,
+                rotate: false
+              })
+            } else {
+              await this.viewer.setImage(vtkImage)
+            }
+          }
+          else{
+            throw new Error("Unsupported image type")
           }
         }
       })

--- a/dist/index.html
+++ b/dist/index.html
@@ -83,7 +83,7 @@
             this.viewer = await itkVtkViewer.processURLParameters(container, {image})
           }
           // load image from a File object
-          else if(image instanceof File){
+          else if(image instanceof Blob){
             this.viewer = await itkVtkViewer.createViewerFromFiles(container, [image])
           }
           // load image from a list of file URL or files
@@ -91,7 +91,7 @@
             if(typeof image[0] === 'string') {
               this.viewer = await itkVtkViewer.processURLParameters(container, {filesToLoad: image.join(",")})
             }
-            else if(image[0] instanceof File){
+            else if(image[0] instanceof Blob){
               this.viewer = await itkVtkViewer.createViewerFromFiles(container, image)
             }
           }

--- a/doc/content/docs/imjoy.md
+++ b/doc/content/docs/imjoy.md
@@ -27,9 +27,40 @@ https://unpkg.com/itk-vtk-viewer@10.8.0/dist/index.html
 
 Supported context `data` inputs:
 
-**image**: Image to be visualized. Can be an [itk.js Image](https://insightsoftwareconsortium.github.io/itk-js/api/Image.html) or an [imjoy-rpc](https://github.com/imjoy-team/imjoy-rpc) encoded ndarray for JavaScript; for Python, it can be a [numpy](https://numpy.org) array.
+**image**: Image to be visualized. See **setImage(image)** API function for the supported image types.
 
-For [scijs ndarray](http://scijs.net/packages/#scijs/ndarray), you can use the following function to encoded it into an imjoy-rpc encoded array.
+
+The `image` key is optional; one can also call `setImage()` later.
+
+Usage in javascript:
+```javascript
+const viewer = await api.createWindow({
+  src: "https://kitware.github.io/itk-vtk-viewer/app/",
+  data: { image: "https://thewtex.github.io/allen-ccf-itk-vtk-zarr/average_template_50_chunked.zarr"}
+  })
+```
+
+Usage in Python
+```python
+# a 2D or 3D numpy array
+image_array = np.random.randint(0, 255, [500, 500], dtype='uint8')
+viewer = await api.createWindow(src="https://kitware.github.io/itk-vtk-viewer/app/",
+                                data={"image": image_array})
+```
+
+## API functions
+
+In addition to the standard `setup` and `run` methods, the *itk-vtk-viewer* plugin provides the following methods:
+
+### setImage(image)
+
+Set the image to be visualized. It can be one of the following:
+  - An [itk.js Image](https://insightsoftwareconsortium.github.io/itk-js/api/Image.html)
+  - An [imjoy-rpc](https://github.com/imjoy-team/imjoy-rpc) encoded ndarray for JavaScript; for Python, it can be a [numpy](https://numpy.org) array
+  - An image `File` or `FileList` (can also be an array of `File`) in Javascript
+  - A URL or a list of URLs to a remote image file (e.g. a zarr file)
+
+If you want to pass a [scijs ndarray](http://scijs.net/packages/#scijs/ndarray) to `setImage`, you can use the following function to encoded it into an imjoy-rpc encoded array.
 ```
 function encodeScijsArray(array){
   return {
@@ -40,30 +71,3 @@ function encodeScijsArray(array){
   }
 }
 ```
-
-The `image` key is optional; one can also call `setImage()` later.
-
-Usage in javascript:
-```javascript
-const imageArray = ... // itk.js Image or imjoy-rpc encoded ndarray
-const viewer = await api.createWindow({
-  src: "https://kitware.github.io/itk-vtk-viewer/app/",
-  data: { image: imageArray }
-  })
-```
-
-Usage in Python
-```python
-# a 2D or 3D numpy array
-image_array = np.random.randint(0, 255, [500, 500], dtype='uint8')
-viewer = await api.createWindow(src="https://kitware.github.io/itk-vtk-viewer/app/",
-                                data={"image": imageArray})
-```
-
-## API functions
-
-In addition to the standard `setup` and `run` methods, the *itk-vtk-viewer* plugin provides the following methods:
-
-### setImage(image)
-
-Set the image to be visualized. Can be an [itk.js Image](https://insightsoftwareconsortium.github.io/itk-js/api/Image.html) or an [imjoy-rpc](https://github.com/imjoy-team/imjoy-rpc) encoded ndarray for JavaScript; for Python, it can be a [numpy](https://numpy.org) array.

--- a/test/imjoyTest.js
+++ b/test/imjoyTest.js
@@ -88,7 +88,14 @@ test('Test ImJoy Plugin', async t => {
     data: { image: itkImage },
   })
   await viewer.setImage(encodeArray(array))
-
+  await viewer.setImage(testImage3DPath)
+  await viewer.setImage([testImage3DPath])
+  const file = new File(
+    [new Blob([response.data], { type: 'application/octet-stream' })],
+    'data.nrrd'
+  )
+  await viewer.setImage(file)
+  await viewer.setImage([file])
   imjoy.destroy()
   console.log('ImJoy destroyed')
   gc.releaseResources()


### PR DESCRIPTION
This PR allows passing more image types into the `setImage` ImJoy API:
 * a URL or a list of URLs
 * a file or a list of files

For example, we can do:
```python
await viewer.setImage("https://thewtex.github.io/allen-ccf-itk-vtk-zarr/average_template_50_chunked.zarr")
```