### PR TITLE
fix(applyRenderedImage): Create a copy of the color range before sending

### DIFF
--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -182,7 +182,7 @@ function applyRenderedImage(context, event) {
           return
         }
         const dataArray = actorContext.fusedImage.getPointData().getScalars()
-        const range = dataArray.getRange(fusedImageIndex)
+        const range = dataArray.getRange(fusedImageIndex).slice()
         if (!actorContext.colorRangeBounds.has(componentIndex)) {
           context.service.send({
             type: 'IMAGE_COLOR_RANGE_BOUNDS_CHANGED',


### PR DESCRIPTION
Otherwise an Array reference is sent and all components end up with the
range of the last component.
