### PR TITLE
fix(WebPack): Produce UMD library target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,9 @@ module.exports = [
     module: moduleConfig,
     output: {
       filename: 'itkVtkViewer.js',
+      library: 'itkVtkViewer',
+      libraryTarget: 'umd',
+      umdNamedDefine: true,
     },
     resolve: {
       fallback: { fs: false, stream: require.resolve('stream-browserify') },


### PR DESCRIPTION
With this PR we will be able to use the produce node module like this:
```js
import * as itkVtkViewer from "itk-vtk-viewer";
```

I am not sure whether this is the best way to do it, but I generate umd module for my other projects.