### PR TITLE
version cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "build": "webpack --progress --color --mode production",
     "build:debug": "webpack --progress --color --mode development",
     "build:release": "npm run build",
+    "prepublishOnly": "npm run build",
     "bundle": "StandaloneHTML ./dist/index.html ./dist/ItkVtkViewer.html",
     "commit": "git cz",
     "format": "prettier --write src/UserInterface/**/*.js src/*.js",

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,11 @@ import readImageArrayBuffer from 'itk/readImageArrayBuffer'
 import createViewer from './createViewer'
 
 import imJoyPluginAPI from './imJoyPluginAPI'
+import { version } from '../package.json'
 
 let doNotInitViewers = false
 
+export { version }
 export { imJoyPluginAPI }
 export { default as createViewer } from './createViewer'
 import * as utils from './utils.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ const cssRules = require('vtk.js/Utilities/config/dependency.js').webpack.css
   .rules
 
 const packageJSON = require('./package.json')
-const itkVersion = packageJSON.dependencies.itk.substring(1)
-const cdnPath = 'https://unpkg.com/itk@' + itkVersion
+const version = packageJSON.version
+const cdnPath = `https://unpkg.com/itk-vtk-viewer@${version}/dist/itk`
 
 const devServer = {
   noInfo: true,


### PR DESCRIPTION
- fix(NPM): Run Webpack build during prepublishOnly
- fix(index): Export the package version
- fix(Webpack): Use the itk-vtk-viewer Unpkg for the CDN path
