### PR TITLE
fix(index.js): replace deleted function setUserInterfaceCollapsed for setUICollapsed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ export function initializeEmbeddedViewers() {
           viewer.setBackgroundColor(bgColor)
         }
 
-        viewer.setUserInterfaceCollapsed(true)
+        viewer.setUICollapsed(true)
         // Render
         if (viewer.renderWindow && viewer.renderWindow.render) {
           viewer.renderWindow.render()


### PR DESCRIPTION
`setUserInterfaceCollapsed` was refactored to `setUICollapsed` here:
b3b74272666d8d200f7c3461bbc4c2c6fd2d4707
