### PR TITLE
fix(package.json): fix commitizen config path to allow working with globally installed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "config": {
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     }
   },
   "bin": {


### PR DESCRIPTION
Following instructions from https://github.com/commitizen/cz-cli