### PR TITLE
fix(Safari): Work around lack of BigUint64Array

### DIFF
--- a/src/IO/dtypeToTypedArray.js
+++ b/src/IO/dtypeToTypedArray.js
@@ -1,3 +1,11 @@
+// Currently missing on Safari
+const bigIntArrayType =
+  typeof window.BigInt64Array === 'function' ? window.BigInt64Array : Int32Array
+const bigUintArrayType =
+  typeof window.BigUint64Array === 'function'
+    ? window.BigUint64Array
+    : Uint32Array
+
 const dtypeToTypedArray = new Map([
   ['<b', Int8Array],
   ['<B', Uint8Array],
@@ -9,8 +17,8 @@ const dtypeToTypedArray = new Map([
   ['<i2', Int16Array],
   ['<u4', Uint32Array],
   ['<i4', Int32Array],
-  ['<u8', BigUint64Array],
-  ['<i8', BigInt64Array],
+  ['<u8', bigUintArrayType],
+  ['<i8', bigIntArrayType],
 
   ['<f4', Float32Array],
   ['<f8', Float64Array],


### PR DESCRIPTION
Addresses failure during loading: `ReferenceError: Can't find variable:
BigUint64Array`.
