### PR TITLE
build(Webpack): Enable devServer writeToDisk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const devServer = {
   noInfo: true,
   stats: 'minimal',
   port: 8080,
+  writeToDisk: true,
 }
 
 const moduleConfig = {


### PR DESCRIPTION
This should help with the ImJoy tests when `npm run build` is not run
before `npm test`.
