### PR TITLE
test(Docker): Bump CI image for Ubuntu 20.04

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -3,7 +3,7 @@
 # Source: https://github.com/thewtex/docker-opengl/tree/webgl
 
 container=webgl
-image=thewtex/opengl:ubuntu1804
+image=thewtex/opengl:ubuntu2004
 port=6080
 extra_run_args=""
 quiet=""


### PR DESCRIPTION
Updates:

- Chrome 88.4324.182
- Firefox 86
- Node 12.21.0
- NPM 6.14.11
