### PR TITLE
fix(createRenderer): Load vtk.js rendering profiles

### DIFF
--- a/src/Rendering/VTKJS/createRenderer.js
+++ b/src/Rendering/VTKJS/createRenderer.js
@@ -1,6 +1,11 @@
 import vtkProxyManager from 'vtk.js/Sources/Proxy/Core/ProxyManager'
 import proxyConfiguration from './proxyManagerConfiguration'
 
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import 'vtk.js/Sources/Rendering/Profiles/Geometry'
+import 'vtk.js/Sources/Rendering/Profiles/Glyph'
+import 'vtk.js/Sources/Rendering/Profiles/Volume'
+
 function createRenderer(context) {
   //const proxyManager = vtkProxyManager.newInstance({ proxyConfiguration })
   //context.proxyManager = proxyManager


### PR DESCRIPTION
Required with vtk.js 18 and later.
