### PR TITLE
fix(SlicingPlanes): Enable by default

### DIFF
--- a/src/Context/MainMachineContext.js
+++ b/src/Context/MainMachineContext.js
@@ -65,7 +65,7 @@ class MainMachineContext {
       step: 0.1,
       scroll: false,
       scrollDirection: 1,
-      visible: false,
+      visible: true,
     },
     y: {
       min: 0.0,
@@ -73,7 +73,7 @@ class MainMachineContext {
       step: 0.1,
       scroll: false,
       scrollDirection: 1,
-      visible: false,
+      visible: true,
     },
     z: {
       min: 0.0,
@@ -81,7 +81,7 @@ class MainMachineContext {
       step: 0.1,
       scroll: false,
       scrollDirection: 1,
-      visible: false,
+      visible: true,
     },
   }
 


### PR DESCRIPTION
Enable slicing planes by default in the 3D view.

The slicing planes are a helpful visualization. And, until we refine our
default gradient opacity setting for all datasets, there will always be
something other than a blank scene (if it is too high).

BREAKING_CHANGE: 3D slicing planes are enabled by default
