### PR TITLE
build(webpack): set the publicPath to an empty string

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = (env, argv) => [
     devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
     output: {
       filename: 'itkVtkViewer.js',
+      publicPath: '',
     },
     resolve: {
       alias: {


### PR DESCRIPTION
Automatic publicPath is not always supported.