### PR TITLE
Webpack Public Path to import 'itk-vtk-viewer' downstream 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -87,6 +87,12 @@ module.exports = function init(config) {
         included: false,
       },
       {
+        pattern: './dist/pipeline.worker.js',
+        watched: true,
+        served: true,
+        included: false,
+      },
+      {
         pattern: './src/UI/reference-ui/dist/referenceUIMachineOptions.js',
         watched: true,
         served: true,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ declare type ndarray = {
   _rtype: 'ndarray'
 }
 
-declare type LoadableImage = URL | Image | Store | ndarray
+declare type LoadableImage = URL | Store | ndarray | Image
 
 declare type ViewerOptions = {
   image?: LoadableImage
@@ -20,7 +20,7 @@ declare type ViewerOptions = {
 
 type Viewer = {
   setBackgroundColor(color: [number, number, number]): void
-  setImageColorMap(mapName: string, actor: number): void
+  setImageColorMap(mapName: string, actor?: number): void
 }
 
 declare namespace itkVtkViewer {
@@ -51,3 +51,6 @@ declare namespace itkVtkViewer {
 
   type version = string
 }
+
+export as namespace itkVtkViewer
+export = itkVtkViewer

--- a/src/itkConfig.js
+++ b/src/itkConfig.js
@@ -1,8 +1,8 @@
 const itkConfig = {
-  pipelineWorkerUrl: __webpack_public_path__ + 'itk/web-workers/min-bundles/pipeline.worker.js', // eslint-disable-line no-undef
-  imageIOUrl: __webpack_public_path__ + 'itk/image-io', // eslint-disable-line no-undef
-  meshIOUrl: __webpack_public_path__ + 'itk/mesh-io', // eslint-disable-line no-undef
-  pipelinesUrl: __webpack_public_path__ + 'itk/pipeline', // eslint-disable-line no-undef
+  pipelineWorkerUrl: 'pipeline.worker.js', // eslint-disable-line no-undef
+  imageIOUrl: 'itk/image-io', // eslint-disable-line no-undef
+  meshIOUrl: 'itk/mesh-io', // eslint-disable-line no-undef
+  pipelinesUrl: 'itk/pipeline', // eslint-disable-line no-undef
 }
 
 export default itkConfig

--- a/src/itkConfig.js
+++ b/src/itkConfig.js
@@ -1,8 +1,8 @@
 const itkConfig = {
-  pipelineWorkerUrl: 'pipeline.worker.js', // eslint-disable-line no-undef
-  imageIOUrl: 'itk/image-io', // eslint-disable-line no-undef
-  meshIOUrl: 'itk/mesh-io', // eslint-disable-line no-undef
-  pipelinesUrl: 'itk/pipeline', // eslint-disable-line no-undef
+  pipelineWorkerUrl: 'pipeline.worker.js',
+  imageIOUrl: 'itk/image-io',
+  meshIOUrl: 'itk/mesh-io',
+  pipelinesUrl: 'itk/pipeline',
 }
 
 export default itkConfig

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = (env, argv) => [
     devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
     output: {
       filename: 'itkVtkViewer.js',
+      publicPath: '',
     },
     resolve: {
       alias: {
@@ -93,6 +94,18 @@ module.exports = (env, argv) => [
               'web-workers'
             ),
             to: path.join(__dirname, 'dist', 'itk', 'web-workers'),
+          },
+          {
+            from: path.join(
+              __dirname,
+              'node_modules',
+              'itk-wasm',
+              'dist',
+              'web-workers',
+              'min-bundles',
+              'pipeline.worker.js'
+            ),
+            to: path.join(__dirname, 'dist', 'pipeline.worker.js'),
           },
           {
             from: path.join(__dirname, 'node_modules', 'itk-image-io'),


### PR DESCRIPTION
To use the pre-built itk-vtk-viewer bundle as a upstream dependency we:
- Change Webpack's publicPath to `''` (document relative) rather than the default `auto`.  publicPath as `auto` caused a `automatic publicpath is not supported in this browser` error when including itk-vtk-viewer in the bundle.
- Lift itk-wasm's pipeline.worker.js to live at the same level as the bundle, so the document/worker.js relative publicPath still lets the worker find the .wasm files.  Before, the theory is publicPath resolved to an absolute path, so .wasm files were found no matter pipeline.workers.js' location.

This change allows for a vite project to 
```
import 'itk-vtk-viewer'
itkVtkViewer.createViewer(...
```
With a `vite.config.js` like this
```
import { fileURLToPath, URL } from 'url'
import { viteStaticCopy } from 'vite-plugin-static-copy'
import { defineConfig } from 'vite'

export default defineConfig({
  optimizeDeps: {
    include: ['itk-vtk-viewer'],
  },
  plugins: [
    viteStaticCopy({
      targets: [
        { src: 'node_modules/itk-vtk-viewer/dist/pipeline.worker.js', dest: '' },
        { src: 'node_modules/itk-vtk-viewer/dist/itk', dest: '' },
      ],
    }),
  ],
```
Still have to lift up the pipeline.worker.js and the .wasms =(

Inspired by #475 