### PR TITLE
fix(ZarrMultiscaleSpatialImage): handle axes of just strings

### DIFF
--- a/src/IO/ZarrMultiscaleSpatialImage.js
+++ b/src/IO/ZarrMultiscaleSpatialImage.js
@@ -53,7 +53,7 @@ export const computeTransform = (imageMetadata, datasetMetadata, dimCount) => {
   )
 }
 
-// lazy creation of voxel/pixel/dimenstion coordinates array
+// lazy creation of voxel/pixel/dimension coordinates array
 const makeCoords = ({ shape, multiscaleImage, dataset }) => {
   const axes = multiscaleImage.axes?.map(({ name }) => name) ?? TCZYX
   const coords = new Map(axes.map(dim => [dim, null]))
@@ -111,8 +111,8 @@ const createScaledImageInfo = async ({
 
   const dims =
     scaleZattrs._ARRAY_DIMENSIONS ??
-    multiscaleImage.axes?.map(({ name }) => name) ??
-    TCZYX // defautl to TCZYX for NGFF v0.1
+    multiscaleImage.axes?.map(axis => axis.name ?? axis) ??
+    TCZYX // default to TCZYX for NGFF v0.1
 
   const { shape, chunks } = pixelArrayMetadata
 


### PR DESCRIPTION
Supports this data:

https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001240.zarr

where axes metadata is `['c', 'z', 'y', 'x']` rather than `[ {name: 'c' ...} ... ]`