### PR TITLE
fix(jsDelivr): Remove files from the packaged distribution to get under limit

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,7 @@ src/Compression/blosc-zarr
 test
 src/Compression/blosc-zarr/web-build
 src/IO/Downsample/web-build
+.github
+dist/itk/image-io/node_modules
+dist/itk/mesh-io/node_modules
+dist/*.map


### PR DESCRIPTION
94 MB < 100 MB limit. Closes #514.
