### PR TITLE
fix(scaleSelector): error when uiMachineOptions missing scaleSelector

### DIFF
--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -355,7 +355,8 @@ function createImagesUIMachine(options, context) {
         },
       },
     },
-    options
+    // need scaleSelector service stub to avoid errors if overridden options does not define
+    { services: { scaleSelector: () => () => undefined }, ...options }
   )
 }
 


### PR DESCRIPTION
If custom config does not include uiMachineOptions.images.services.scaleSelector
there is an state machine error:
Error: Unable to send event to child 'scaleSelector' from service 'images'.

This change provides default stub for the scaleSelector

closes #516