### PR TITLE
Fixes for fuseComponents and component checkbox UI

### DIFF
--- a/src/Rendering/VTKJS/Images/FuseComponents.worker.js
+++ b/src/Rendering/VTKJS/Images/FuseComponents.worker.js
@@ -1,8 +1,11 @@
 import registerWebworker from 'webworker-promise/lib/register'
 import { computeRanges, fuseComponents } from './fuseImagesUtils'
 
-registerWebworker(async ({ componentInfo, existingArray }) => {
-  const imageArray = fuseComponents({ componentInfo, existingArray })
+registerWebworker(async ({ componentInfo, arrayToFill }) => {
+  const imageArray = fuseComponents({
+    componentInfo,
+    arrayToFill,
+  })
   const componentRanges = await computeRanges(imageArray, componentInfo.length)
   return new registerWebworker.TransferableResponse(
     [imageArray, componentRanges],

--- a/src/Rendering/VTKJS/Images/fuseImages.js
+++ b/src/Rendering/VTKJS/Images/fuseImages.js
@@ -51,7 +51,7 @@ export const fuseImages = async ({
   const isExistingArrayMatchingNeed =
     existingArray &&
     existingArray.length === elementCount &&
-    typeof oldFusedData === typeof largestType // Avoid losing data if TypedArrays are different between images
+    typeof existingArray === typeof largestType // Avoid losing data if TypedArrays are different between images
   const arrayToFill = isExistingArrayMatchingNeed ? existingArray : undefined
 
   // Prep for worker.postMessage arguments \\
@@ -64,8 +64,8 @@ export const fuseImages = async ({
   const transferables = []
   if (
     arrayToFill &&
-    !haveSharedArrayBuffer &&
-    !(arrayToFill.buffer instanceof SharedArrayBuffer)
+    (!haveSharedArrayBuffer ||
+      !(arrayToFill.buffer instanceof SharedArrayBuffer))
   )
     transferables.push(arrayToFill.buffer)
 

--- a/src/Rendering/VTKJS/Images/fuseImages.js
+++ b/src/Rendering/VTKJS/Images/fuseImages.js
@@ -1,19 +1,13 @@
 import WebworkerPromise from 'webworker-promise'
 import FuseComponentsWorker from './FuseComponents.worker'
-import {
-  countElements,
-  getLargestTypeByBytes,
-  parseByComponent,
-} from './fuseImagesUtils'
+import { parseByComponent } from './fuseImagesUtils'
 
-const haveSharedArrayBuffer = typeof window.SharedArrayBuffer === 'function'
 let worker
 
 export const fuseImages = async ({
   imageAtScale,
   labelAtScale,
   visualizedComponents,
-  existingArray,
 }) => {
   const [imageByComponent, labelByComponent] = [
     imageAtScale,
@@ -43,40 +37,15 @@ export const fuseImages = async ({
       [undefined, []]
     )
 
-  const elementCount = countElements(componentInfo)
-  const largestType = getLargestTypeByBytes(componentInfo)
-
-  // We only need to construct a new typed array if we don't already
-  // have one of the right length.
-  const isExistingArrayMatchingNeed =
-    existingArray &&
-    existingArray.length === elementCount &&
-    typeof existingArray === typeof largestType // Avoid losing data if TypedArrays are different between images
-  const arrayToFill = isExistingArrayMatchingNeed ? existingArray : undefined
-
-  // Prep for worker.postMessage arguments \\
-
   // eslint-disable-next-line no-unused-vars
   const componentInfoSansImage = componentInfo.map(({ image, ...rest }) => ({
     ...rest,
   }))
 
-  const transferables = []
-  if (
-    arrayToFill &&
-    (!haveSharedArrayBuffer ||
-      !(arrayToFill.buffer instanceof SharedArrayBuffer))
-  )
-    transferables.push(arrayToFill.buffer)
-
   if (!worker) worker = new WebworkerPromise(new FuseComponentsWorker())
-  const [fusedImageData, componentRanges] = await worker.postMessage(
-    {
-      componentInfo: componentInfoSansImage,
-      arrayToFill,
-    },
-    transferables
-  )
+  const [fusedImageData, componentRanges] = await worker.postMessage({
+    componentInfo: componentInfoSansImage,
+  })
 
   const base = imageByComponent[0]?.image ?? labelByComponent[0]?.image
   const fusedItkImage = {

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -49,7 +49,6 @@ async function updateRenderedImage(context) {
         imageAtScale,
         labelAtScale,
         visualizedComponents: actorContext.visualizedComponents,
-        existingArray: actorContext.fusedImageData,
       })
     : [
         imageAtScale,

--- a/src/Rendering/VTKJS/Images/updateVisualizedComponents.js
+++ b/src/Rendering/VTKJS/Images/updateVisualizedComponents.js
@@ -13,10 +13,10 @@ function updateVisualizedComponents(context, name) {
     }
 
     actorContext.maxIntensityComponents = 4
-    if (!!labelImage) {
+    if (labelImage) {
       actorContext.maxIntensityComponents -= 1
     }
-    if (!!editorLabelImage) {
+    if (editorLabelImage) {
       actorContext.maxIntensityComponents -= 1
     }
 
@@ -24,17 +24,21 @@ function updateVisualizedComponents(context, name) {
       imageComponents,
       actorContext.maxIntensityComponents
     )
-    if (!actorContext.visualizedComponents.length <= numVizComps) {
+    if (actorContext.visualizedComponents.length > numVizComps) {
+      // turn off unrenderable components
       actorContext.visualizedComponents = actorContext.visualizedComponents.slice(
         0,
         numVizComps
       )
-      for (let i = numVizComps; i < imageComponents; i++) {
+      const offComps = [...Array(imageComponents).keys()].filter(
+        comp => !actorContext.visualizedComponents.includes(comp)
+      )
+      offComps.forEach(comp =>
         context.service.send({
           type: 'IMAGE_COMPONENT_VISIBILITY_CHANGED',
-          data: { name, component: i, visibility: false },
+          data: { name, component: comp, visibility: false },
         })
-      }
+      )
     }
   }
   if (labelImage) {

--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -23,10 +23,10 @@ const assignComponentVisibility = assign({
       // A component was made visible, and it was not already in the list
       // of visualized components
       const currentNumVisualized = componentVisibilities.reduce(
-        (a, c) => (c + a) | 0,
+        (a, c) => c + a,
         0
       )
-      if (currentNumVisualized.length >= actorContext.maxIntensityComponents) {
+      if (currentNumVisualized + 1 > actorContext.maxIntensityComponents) {
         // Find the index in the visulized components list of the last touched
         // component.  We need to replace it with this component the user just
         // turned on.
@@ -35,9 +35,9 @@ const assignComponentVisibility = assign({
         ] = false
       }
     }
+    if (visibility) actorContext.lastComponentVisibilityChanged = index
 
     componentVisibilities[index] = visibility
-    actorContext.lastComponentVisibilityChanged = index
 
     return images
   },


### PR DESCRIPTION
When 4 components were ON and user clicked checkbox of OFF component,
sometimes it turned on, sometimes it did not.  Fixed.

If new fused image takes some time to build in worker and user changes
rendering parameters of current image, there would be an error as the
current image buffer was transferred to worker.  Changed to no longer transfer array.