### PR TITLE
Add Local ambient occlusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-release",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@kitware/vtk.js": "^25.2.4",
+        "@kitware/vtk.js": "^25.8.2",
         "@thewtex/iconselect.js": "^2.1.2",
         "@xstate/inspect": "^0.4.1",
         "axios": "^0.21.1",
@@ -30,7 +30,7 @@
         "promise-file-reader": "^1.0.3",
         "promise.any": "^2.0.2",
         "regenerator-runtime": "^0.13.7",
-        "vtk.js": "^25.2.4",
+        "vtk.js": "^25.8.2",
         "webworker-promise": "^0.4.2",
         "xstate": "^4.16.2"
       },
@@ -3971,21 +3971,20 @@
       }
     },
     "node_modules/@kitware/vtk.js": {
-      "version": "25.2.4",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.2.4.tgz",
-      "integrity": "sha512-wPWJJ76eo72q0HqbahenqlXzgwkZwzrfD4/zkzSgjUP/W4l93y60wGzQyIsu4rxgmiJhYuWZ0MuPySqiwEDS5g==",
+      "version": "25.8.2",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.8.2.tgz",
+      "integrity": "sha512-lWhaASAR8xlNykrpiepr/yIE7SYu/MrWM1dh/ofq6IDeBajX81GdUvaBB1eiP8QF7/gWq0wJCnBNS0OzbIBZcA==",
       "dependencies": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
@@ -7274,7 +7273,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -9432,6 +9432,11 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -11007,11 +11012,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
     "node_modules/import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -12059,7 +12059,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -12773,36 +12774,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
-      "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "node_modules/jszip/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/karma": {
       "version": "6.3.16",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.16.tgz",
@@ -13070,14 +13041,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -17457,11 +17420,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
-    },
     "node_modules/parallel-webpack": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/parallel-webpack/-/parallel-webpack-2.6.0.tgz",
@@ -18763,7 +18721,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -20255,14 +20214,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -22358,21 +22309,20 @@
       }
     },
     "node_modules/vtk.js": {
-      "version": "25.2.4",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.2.4.tgz",
-      "integrity": "sha512-eoEoQrr0KI/zHF3JTj93E3Bo2PkMm7pHB4PDkU7UWfot1r5eOpV18afXn+1a+1/zvVysRXdGcDC2wwBK9WKnZQ==",
+      "version": "25.8.2",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.8.2.tgz",
+      "integrity": "sha512-eWbewArxglNLNaC5MIJndXeVlc4H/W0ZsQkfEYsGgEOsmPB/NStdUpCrC/OUhhCSFtJzTEka802nqjV+ImhurQ==",
       "dependencies": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
@@ -27415,21 +27365,20 @@
       }
     },
     "@kitware/vtk.js": {
-      "version": "25.2.4",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.2.4.tgz",
-      "integrity": "sha512-wPWJJ76eo72q0HqbahenqlXzgwkZwzrfD4/zkzSgjUP/W4l93y60wGzQyIsu4rxgmiJhYuWZ0MuPySqiwEDS5g==",
+      "version": "25.8.2",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.8.2.tgz",
+      "integrity": "sha512-lWhaASAR8xlNykrpiepr/yIE7SYu/MrWM1dh/ofq6IDeBajX81GdUvaBB1eiP8QF7/gWq0wJCnBNS0OzbIBZcA==",
       "requires": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
@@ -30095,7 +30044,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -31759,6 +31709,11 @@
         "pend": "~1.2.0"
       }
     },
+    "fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -32960,11 +32915,6 @@
         }
       }
     },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
     "import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -33748,7 +33698,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "4.0.10",
@@ -34340,38 +34291,6 @@
         "verror": "1.10.0"
       }
     },
-    "jszip": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.9.1.tgz",
-      "integrity": "sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==",
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
-    },
     "karma": {
       "version": "6.3.16",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.16.tgz",
@@ -34575,14 +34494,6 @@
         "node-forge": "^1.2.1",
         "protobufjs": "^6.11.2",
         "uint8arrays": "^3.0.0"
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
       }
     },
     "lilconfig": {
@@ -37756,11 +37667,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
-    },
     "parallel-webpack": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/parallel-webpack/-/parallel-webpack-2.6.0.tgz",
@@ -38687,7 +38593,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -39854,11 +39761,6 @@
         "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -41549,21 +41451,20 @@
       "dev": true
     },
     "vtk.js": {
-      "version": "25.2.4",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.2.4.tgz",
-      "integrity": "sha512-eoEoQrr0KI/zHF3JTj93E3Bo2PkMm7pHB4PDkU7UWfot1r5eOpV18afXn+1a+1/zvVysRXdGcDC2wwBK9WKnZQ==",
+      "version": "25.8.2",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-25.8.2.tgz",
+      "integrity": "sha512-eWbewArxglNLNaC5MIJndXeVlc4H/W0ZsQkfEYsGgEOsmPB/NStdUpCrC/OUhhCSFtJzTEka802nqjV+ImhurQ==",
       "requires": {
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",
-        "jszip": "3.9.1",
-        "pako": "2.0.4",
         "seedrandom": "3.0.5",
         "shader-loader": "1.3.1",
         "shelljs": "0.8.5",
-        "spark-md5": "^3.0.2",
+        "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "main": "./dist/itkVtkViewer.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@kitware/vtk.js": "^25.2.4",
+    "@kitware/vtk.js": "^25.8.2",
     "@thewtex/iconselect.js": "^2.1.2",
     "@xstate/inspect": "^0.4.1",
     "axios": "^0.21.1",
@@ -51,7 +51,7 @@
     "promise-file-reader": "^1.0.3",
     "promise.any": "^2.0.2",
     "regenerator-runtime": "^0.13.7",
-    "vtk.js": "^25.2.4",
+    "vtk.js": "^25.8.2",
     "webworker-promise": "^0.4.2",
     "xstate": "^4.16.2"
   },

--- a/src/Context/ImageActorContext.js
+++ b/src/Context/ImageActorContext.js
@@ -83,6 +83,14 @@ class ImageActorContext {
   // Volume rendering blend mode
   blendMode = 'Composite'
 
+  cinematicParameters = {
+    isCinematicOn: false,
+    laoKernelSize: 5, // number of rays cast for Local Ambient Occlusion
+    laoKernelRadius: 10, // distance rays travel for Local Ambient Occlusion
+    diffuse: 1.2,
+    ambient: 0.6,
+  }
+
   // Name of the labelImage layer
   labelImageName = null
 

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -107,6 +107,27 @@ const assignIsFramerateScalePickingOn = assign({
   },
 })
 
+const assignToggleCinematic = assign({
+  images: ({ images }, { data: { params, name } }) => {
+    const actorContext = images.actorContext.get(name)
+    actorContext.cinematicParameters = {
+      ...actorContext.cinematicParameters,
+      ...params,
+    }
+    return images
+  },
+})
+
+const sendCinematicChanged = context => {
+  const actorContext = context.images.actorContext.get(
+    context.images.selectedName
+  )
+  context.service.send({
+    type: 'CINEMATIC_CHANGED',
+    actorContext,
+  })
+}
+
 const KNOWN_ERRORS = [
   'Voxel count over max at scale',
   "Failed to execute 'postMessage' on 'Worker': Data cannot be cloned, out of memory.",
@@ -218,6 +239,12 @@ const eventResponses = {
   },
   RENDERED_BOUNDS_CHANGED: {
     target: 'updatingImage',
+  },
+  SET_CINEMATIC_PARAMETERS: {
+    actions: [assignToggleCinematic, sendCinematicChanged],
+  },
+  CINEMATIC_CHANGED: {
+    actions: 'applyCinematicChanged',
   },
 }
 

--- a/src/Rendering/Images/createImagesRenderingMachine.js
+++ b/src/Rendering/Images/createImagesRenderingMachine.js
@@ -89,6 +89,16 @@ function createImagesRenderingMachine(options, context) {
                 to: c => `imageRenderingActor-${c.images.updateRenderedName}`,
               }),
             },
+            SET_CINEMATIC_PARAMETERS: {
+              actions: send((_, e) => e, {
+                to: c => `imageRenderingActor-${c.images.selectedName}`,
+              }),
+            },
+            CINEMATIC_CHANGED: {
+              actions: send((_, e) => e, {
+                to: c => `imageRenderingActor-${c.images.selectedName}`,
+              }),
+            },
             TOGGLE_LAYER_VISIBILITY: {
               actions: send((_, e) => e, {
                 to: c => `imageRenderingActor-${c.images.selectedName}`,

--- a/src/Rendering/VTKJS/Images/applyCinematicChanged.js
+++ b/src/Rendering/VTKJS/Images/applyCinematicChanged.js
@@ -1,0 +1,52 @@
+import vtkLight from 'vtk.js/Sources/Rendering/Core/Light'
+import {
+  VOLUME_AMBIENT_DEFAULT,
+  VOLUME_DIFFUSE_DEFAULT,
+} from '../vtk/ItkVtkViewProxy'
+
+export function applyCinematicChanged(context, { actorContext }) {
+  if (!context.images.representationProxy) return
+
+  const {
+    cinematicParameters: {
+      isCinematicOn,
+      laoKernelSize,
+      laoKernelRadius,
+      diffuse,
+      ambient,
+    },
+  } = actorContext
+  const renderer = context.itkVtkView.getRenderer()
+  const mapper = context.images.representationProxy.getMapper()
+
+  renderer.removeAllLights()
+  if (isCinematicOn) {
+    const light = vtkLight.newInstance()
+    light.setLightTypeToSceneLight()
+    light.setColor(1, 1, 1)
+    light.setIntensity(1)
+    light.setDirection([1, 1, 1])
+    renderer.addLight(light)
+  } else {
+    renderer.createLight()
+  }
+  renderer.setTwoSidedLighting(!isCinematicOn)
+
+  mapper.setLocalAmbientOcclusion(isCinematicOn)
+  mapper.setLAOKernelSize(laoKernelSize)
+  mapper.setLAOKernelRadius(laoKernelRadius)
+
+  const volumeProps = context.images.representationProxy.getVolumes()
+  volumeProps.forEach(volume => {
+    const vProperty = volume.getProperty()
+    if (isCinematicOn) {
+      vProperty.setDiffuse(diffuse)
+      vProperty.setAmbient(ambient)
+    } else {
+      vProperty.setDiffuse(VOLUME_DIFFUSE_DEFAULT)
+      vProperty.setAmbient(VOLUME_AMBIENT_DEFAULT)
+    }
+  })
+
+  context.service.send('RENDER_LATER')
+}

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -23,6 +23,7 @@ import applySelectedLabel from './applySelectedLabel'
 import mapToPiecewiseFunctionNodes from './mapToPiecewiseFunctionNodes'
 import { getBoundsOfFullImage } from '../Main/croppingPlanes'
 import { computeRenderedBounds } from '../Main/computeRenderedBounds'
+import { applyCinematicChanged } from './applyCinematicChanged'
 
 const EPSILON = 0.000001
 
@@ -90,6 +91,7 @@ const imagesRenderingMachineOptions = {
       applyLabelNames,
       applyLabelImageWeights,
       applySelectedLabel,
+      applyCinematicChanged,
     },
 
     guards: {

--- a/src/Rendering/VTKJS/vtk/ItkVtkViewProxy.js
+++ b/src/Rendering/VTKJS/vtk/ItkVtkViewProxy.js
@@ -13,6 +13,9 @@ import WidgetManagerPickWhileAnimating from './WidgetManagerPickWhileAnimating'
 
 import vtkSliceOutlineFilter from './SliceOutlineFilter'
 
+export const VOLUME_DIFFUSE_DEFAULT = 1.0
+export const VOLUME_AMBIENT_DEFAULT = 0.4
+
 const CursorCornerAnnotation =
   '<table class="corner-annotation" style="margin-left: 0;"><tr><td style="margin-left: auto; margin-right: 0;">Index:</td><td>${iIndex},</td><td>${jIndex},</td><td>${kIndex}</td></tr><tr><td style="margin-left: auto; margin-right: 0;">Position:</td><td>${xPosition},</td><td>${yPosition},</td><td>${zPosition}</td></tr><tr><td style="margin-left: auto; margin-right: 0;"">Value:</td><td style="text-align:center;" colspan="3">${value}</td></tr><tr ${annotationLabelStyle}><td style="margin-left: auto; margin-right: 0;">Label:</td><td style="text-align:center;" colspan="3">${annotation}</td></tr></table>'
 
@@ -954,8 +957,8 @@ function ItkVtkViewProxy(publicAPI, model) {
       model.volumeRepresentation = volumeRepresentations[0]
       const volume = model.volumeRepresentation.getVolumes()[0]
       const property = volume.getProperty()
-      property.setAmbient(0.4)
-      property.setDiffuse(1.0)
+      property.setAmbient(VOLUME_AMBIENT_DEFAULT)
+      property.setDiffuse(VOLUME_DIFFUSE_DEFAULT)
       property.setSpecular(0.4)
       property.setSpecularPower(25)
       const actors = model.volumeRepresentation.getActors()

--- a/src/Rendering/createRenderingMachine.js
+++ b/src/Rendering/createRenderingMachine.js
@@ -62,7 +62,13 @@ const createRenderingMachine = (options, context) => {
               actions: [forwardTo('main'), forwardTo('images')],
             },
             SET_IMAGE_SCALE: {
-              actions: [forwardTo('images')],
+              actions: forwardTo('images'),
+            },
+            SET_CINEMATIC_PARAMETERS: {
+              actions: forwardTo('images'),
+            },
+            CINEMATIC_CHANGED: {
+              actions: forwardTo('images'),
             },
             REQUEST_ANIMATION: {
               actions: 'requestAnimation',

--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -357,6 +357,7 @@ function createImagesUIMachine(options, context) {
             LABEL_IMAGE_SELECTED_LABEL_CHANGED: {
               actions: [assignSelectedLabel, 'applySelectedLabel'],
             },
+            CINEMATIC_CHANGED: { actions: 'applyCinematicChanged' },
           },
         },
       },

--- a/src/UI/createUIMachine.js
+++ b/src/UI/createUIMachine.js
@@ -179,6 +179,9 @@ function createUIMachine(options, context) {
             DISTANCE_WIDGET_VALUE_CHANGED: {
               actions: forwardTo('widgets'),
             },
+            CINEMATIC_CHANGED: {
+              actions: forwardTo('images'),
+            },
           },
           states: {
             // Optional feature of the user interface

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -28,7 +28,7 @@ function styleInject(css, ref) {
 }
 
 var css_248z$1 =
-  ".ItkVtkViewer-module_loading__11c63 {\n  border: 16px solid #f3f3f3; /* Light grey */\n  border-top: 16px solid #3498db; /* Blue */\n  border-radius: 50%;\n  width: 120px;\n  height: 120px;\n  position: absolute;\n  left: calc(50% - 60px);\n  top: calc(50% - 60px);\n  -webkit-animation: ItkVtkViewer-module_spin__mT5S6 2s linear infinite;\n          animation: ItkVtkViewer-module_spin__mT5S6 2s linear infinite;\n  box-sizing: border-box;\n}\n\n@-webkit-keyframes ItkVtkViewer-module_spin__mT5S6 {\n  0% { transform: rotate(0deg); }\n  100% { transform: rotate(360deg); }\n}\n\n@keyframes ItkVtkViewer-module_spin__mT5S6 {\n  0% { transform: rotate(0deg); }\n  100% { transform: rotate(360deg); }\n}\n\n.ItkVtkViewer-module_viewContainer__-5zNz {\n  position: absolute;\n  top: 0;\n  left: 0;\n  bottom: 0;\n  right: 0;\n  display: flex;\n  flex-direction: column;\n  background: rgba(128, 128, 128, 0.8);\n}\n\n.ItkVtkViewer-module_uiContainer__CiawP {\n  display: flex;\n  align-items: stretch;\n  flex-direction: column;\n  justify-content: space-between;\n  position: absolute;\n  top: 5px;\n  left: 5px;\n  padding: 2px;\n  border: 0px;\n  box-sizing: border-box;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_uiGroup__ad-WI {\n  background: rgba(128, 128, 128, 0.5);\n  border-radius: 4px;\n  margin: 2px;\n}\n\n.ItkVtkViewer-module_uiRow__KTQa8 {\n  display: flex;\n  flex-direction: row;\n  flex: 1;\n  align-items: center;\n  justify-content: space-between;\n  padding: 5px;\n}\n\n.ItkVtkViewer-module_mainUIRow__vTXih {\n  justify-content: space-around;\n  max-width: 420px;\n}\n\n.ItkVtkViewer-module_planeUIRow__D5gCh {\n  background: rgba(128, 128, 128, 0.5);\n}\n\n.ItkVtkViewer-module_layersUIRow__0LDm5 {\n  justify-content: space-around;\n  max-width: 420px;\n}\n\n.ItkVtkViewer-module_progress__WydXH {\n  color: white;\n  font-size: 200%;\n  height: 100vh;\n  width: 100vw;\n  text-align: center;\n  vertical-align: middle;\n  line-height: 100vh;\n}\n\n.ItkVtkViewer-module_piecewiseWidget__5gKl5 {\n  flex: 1;\n  background: rgba(255, 255, 255, 0.2);\n  border-radius: 3px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_logo__9ErCF {\n  position: absolute;\n  top: 5px;\n  right: 5px;\n  height: 2.0em;\n  width: 2.0em;\n  cursor: pointer;\n  z-index: 100;\n}\n\n.ItkVtkViewer-module_fpsMonitor__bnwqr {\n  position: absolute;\n  top: 5px;\n  right: 5px;\n  border-radius: 5px;\n  background: rgba(255, 255, 255, 0.6);\n  cursor: pointer;\n  z-index: 101;\n}\n\n[itk-vtk-tooltip] {\n    position: relative;\n}\n[itk-vtk-tooltip]::before {\n    content: attr(itk-vtk-tooltip-content);\n    visibility: hidden;\n    position: absolute;\n    top: 50%;\n    right: calc(100% + 16px);\n    width: 400%;\n    padding: 4px 6px;\n    text-align: center;\n    text-transform: none;\n    font-size: 0.9em;\n    font-family: monospace;\n    border-radius: 3px;\n    background: rgba(0.9, 0.9, 0.9, 0.95);\n    color: white;\n    opacity: 0;\n    transform: translate(15px, -50%);\n    transition-property: all;\n    transition-duration: 0.3s;\n    transition-timing-function: ease-in-out;\n    transition-delay: 0.8s;\n    z-index: 1;\n}\n\n[itk-vtk-tooltip]:hover::before {\n    opacity: 1;\n    visibility: visible;\n    transform: translate(0, -50%);\n}\n\n[itk-vtk-tooltip-bottom]::before {\n    top: calc(100% + 16px);\n    left: 50%;\n    right: initial;\n    transform: translate(-50%, -15px);\n}\n[itk-vtk-tooltip-bottom]:hover::before {\n    transform: translate(-50%, 0)\n}\n[itk-vtk-tooltip-right]::before {\n    top: 50%;\n    left: calc(100% + 16px);\n    right: initial;\n    transform: translate(-15px, -50%);\n}\n[itk-vtk-tooltip-right]:hover::before {\n    transform: translate(0, -50%);\n}\n\n[itk-vtk-tooltip-top-screenshot]::before {\n    top: initial;\n    left: 260%;\n    right: initial;\n    bottom: calc(100% + 8px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-screenshot]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-annotations]::before {\n    top: initial;\n    left: 160%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-annotations]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-axes]::before {\n    top: initial;\n    left: 160%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-axes]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-fullscreen]::before {\n    top: initial;\n    left: 120%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n    width: 400%;\n}\n[itk-vtk-tooltip-top-fullscreen]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top]::before {\n    top: initial;\n    left: 60%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-fullscreen]::before {\n    top: initial;\n    left: 120%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n    width: 400%;\n}\n\n.ItkVtkViewer-module_layerEntryCommon__oIE1u {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: stretch;\n  justify-content: space-between;\n  border-style: solid;\n  border-width: 2px;\n  border-radius: 10%;\n}\n\n.ItkVtkViewer-module_layerEntryBrightBG__qXyI2 {\n  border-color: #666;\n}\n\n.ItkVtkViewer-module_layerEntryDarkBG__BmiCj {\n  border-color: #AAA;\n}\n\n.ItkVtkViewer-module_layerLabelCommon__kTiO9 {\n  border: none;\n  background: transparent;\n  font-size: 1.2em;\n  margin-right: 10px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_layerLabelBrightBG__vAfex {\n  color: black;\n}\n\n.ItkVtkViewer-module_layerLabelDarkBG__sM6Bg {\n  color: white;\n}\n\n.ItkVtkViewer-module_visibleButton__ezrIc {\n  flex-basis: 2.5em;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_visibleButton__ezrIc img {\n  height: 1.2em;\n  width: 1.2em;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n}\n\n.ItkVtkViewer-module_layerIcon__v-rxO img {\n  height: 1.2em;\n  width: 1.2em;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 8px;\n  padding-right: 6px;\n}\n\n.ItkVtkViewer-module_tooltipButtonBrightBG__yffVf::before {\n}\n\n.ItkVtkViewer-module_tooltipButtonDarkBG__gEu0i::before {\n  filter: invert(100%);\n  -webkit-filter: invert(100%);\n}\n\n.ItkVtkViewer-module_invertibleButtonBrightBG__VmIfT {\n}\n\n.ItkVtkViewer-module_invertibleButtonDarkBG__GoKgD {\n  filter: invert(100%);\n  -webkit-filter: invert(100%);\n}\n\n.ItkVtkViewer-module_collapseUIButton__Ac6-L {\n  height: 1.5em;\n  width: 1.5em;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_screenshotButton__OL4Na {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_screenshotButton__OL4Na img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_annotationsButton__Msb-p {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_annotationsButton__Msb-p img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_axesButton__k2H6p {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_axesButton__k2H6p img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_fullscreenButton__en3Z5 {\n  flex: 1;\n  width: 8m;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_fullscreenButton__en3Z5 img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_interpolationButton__2P0HJ {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 2px;\n  padding-right: 4px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_interpolationButton__2P0HJ img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_cropButton__ljwuU {\n  flex: 1;\n  height: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_cropButton__ljwuU img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_resetCropButton__SCGTH {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_resetCropButton__SCGTH img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_distanceEntry__zXMUS {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: self-start;\n}\n\n.ItkVtkViewer-module_distanceButton__NhxBT {\n  flex: 1;\n  height: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_distanceButton__NhxBT img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_distanceLabelCommon__Ec-uc {\n  border: none;\n  background: transparent;\n  font-size: 1.2em;\n  margin-right: 10px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_distanceLabelBrightBG__aYmfG {\n  color: black;\n}\n\n.ItkVtkViewer-module_distanceLabelDarkBG__kYXvI {\n  color: white;\n}\n\n.ItkVtkViewer-module_distanceInput__gyNaU {\n  background: transparent;\n  color: white;\n  font-size: 1.0em;\n  width: 80px;\n}\n\n.ItkVtkViewer-module_resetCameraButton__l9FGp {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_resetCameraButton__l9FGp img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_bgColorButton__yrjOX {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_bgColorButton__yrjOX img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_viewModeButton__OtTng {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_viewModeButton__OtTng img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n.ItkVtkViewer-module_shadowButton__09fEk {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 0px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_shadowButton__09fEk img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n\n.ItkVtkViewer-module_viewPlanesButton__rSnuZ {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 0px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_viewPlanesButton__rSnuZ img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n.ItkVtkViewer-module_toggleInput__jHLTo {\n  margin: 0px;\n  width: 0%;\n  opacity: 0;\n  box-sizing: content-box;\n}\n\n.ItkVtkViewer-module_toggleButton__qHhHZ {\n  cursor: pointer;\n  border-radius: 0.2em;\n  opacity: 0.45;\n}\n\ninput:checked.ItkVtkViewer-module_toggleInput__jHLTo + label {\n  opacity: 1.0;\n}\n\n.ItkVtkViewer-module_numberInput__pDxYH {\n  color: white;\n  background: transparent;\n  font-size: 1.0em;\n  padding-left: 2px;\n  width: 70px;\n}\n\n.ItkVtkViewer-module_selector__yw8l- {\n  display: flex;\n  direction: row;\n  font-size: 1.2em;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF {\n  position: absolute;\n  opacity: 0;\n  pointer-events: none;\n}\n\n.ItkVtkViewer-module_disableInterface__CGB4S {\n  pointer-events: none;\n  opacity: 0.5;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(40, 40, 40, 0.5);\n  padding: 5px;\n  margin-right: 2px;\n  border-radius: 5px 5px 0px 0px;\n  color: #777;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF:hover + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(90, 90, 90, 0.5);\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF:checked + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(127, 127, 127, 0.5);\n  color: #FFF;\n}\n\n.ItkVtkViewer-module_componentVisibility__y1rRS {\n  position: relative;\n  top: -2px;\n  margin-left: 10px;\n}\n\nselect {\n  -moz-appearance: none;\n}\n\nselect option {\n  color: black;\n}\n\nselect:focus {\n  outline: none;\n  border: none;\n}\n\n.ItkVtkViewer-module_sampleDistanceButton__NjT0o {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 6px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_sampleDistanceButton__NjT0o img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_blendModeButton__cit1w {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 8px;\n  padding-right: 0px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_blendModeButton__cit1w img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_gradientOpacitySlider__wkEqP {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 6px;\n  padding-right: 0px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_gradientOpacitySlider__wkEqP img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_sliderEntry__3r3gO {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: center;\n}\n\n.ItkVtkViewer-module_slider__eT9qm {\n  flex: 1;\n  min-height: 1rem;\n  width: 5px;\n}\n\n.ItkVtkViewer-module_planeLabel__E1zOk {\n  padding-left: 6px;\n  padding: 2px;\n  display: block;\n  font-size: 1.1em;\n  font-family: monospace;\n  color: black;\n  border-width: 2px;\n  border-radius: 10%;\n}\n\n.ItkVtkViewer-module_xPlaneLabel__wK4Cb {\n  background-color: #ef5350;\n}\n\n.ItkVtkViewer-module_yPlaneLabel__rIm0j {\n  background-color: #fdd835;\n}\n\n.ItkVtkViewer-module_zPlaneLabel__94NL7 {\n  background-color: #4caf50;\n}\n\n.ItkVtkViewer-module_gradientOpacityScale__NrqOZ {\n  z-index: 1100;\n  position: relative;\n}\n\n.ItkVtkViewer-module_gradientOpacityScale__NrqOZ input {\n  position: absolute;\n  bottom: 20px;\n  left: -24px;\n  width: 12px;\n  -ms-writing-mode: bt-lr;\n      writing-mode: bt-lr;\n  -webkit-appearance: slider-vertical;\n}\n\n.ItkVtkViewer-module_bigFileDrop__cZdkP {\n  position: absolute;\n  left: 50%;\n  top: 50%;\n  transform: translate(-50%, -50%);\n  background-color: white;\n  background-image: url('./dropBG.jpg');\n  background-repeat: no-repeat;\n  background-position: center;\n  background-size: contain;\n  border-radius: 10px;\n  width: 50px;\n  padding: calc(50vh - 2em) calc(50vw - 25px - 2em);\n}\n\n.ItkVtkViewer-module_fullscreenContainer__-H3c8 {\n  position: absolute;\n  width: 100vw;\n  height: 100vh;\n  top: 0;\n  left: 0;\n  overflow: hidden;\n  background: black;\n  margin: 0;\n  padding: 0;\n}\n"
+  ".ItkVtkViewer-module_loading__11c63 {\n  border: 16px solid #f3f3f3; /* Light grey */\n  border-top: 16px solid #3498db; /* Blue */\n  border-radius: 50%;\n  width: 120px;\n  height: 120px;\n  position: absolute;\n  left: calc(50% - 60px);\n  top: calc(50% - 60px);\n  -webkit-animation: ItkVtkViewer-module_spin__mT5S6 2s linear infinite;\n          animation: ItkVtkViewer-module_spin__mT5S6 2s linear infinite;\n  box-sizing: border-box;\n}\n\n@-webkit-keyframes ItkVtkViewer-module_spin__mT5S6 {\n  0% { transform: rotate(0deg); }\n  100% { transform: rotate(360deg); }\n}\n\n@keyframes ItkVtkViewer-module_spin__mT5S6 {\n  0% { transform: rotate(0deg); }\n  100% { transform: rotate(360deg); }\n}\n\n.ItkVtkViewer-module_viewContainer__-5zNz {\n  position: absolute;\n  top: 0;\n  left: 0;\n  bottom: 0;\n  right: 0;\n  display: flex;\n  flex-direction: column;\n  background: rgba(128, 128, 128, 0.8);\n}\n\n.ItkVtkViewer-module_uiContainer__CiawP {\n  display: flex;\n  align-items: stretch;\n  flex-direction: column;\n  justify-content: space-between;\n  position: absolute;\n  top: 5px;\n  left: 5px;\n  padding: 2px;\n  border: 0px;\n  box-sizing: border-box;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_uiGroup__ad-WI {\n  background: rgba(128, 128, 128, 0.5);\n  border-radius: 4px;\n  margin: 2px;\n}\n\n.ItkVtkViewer-module_uiRow__KTQa8 {\n  display: flex;\n  flex-direction: row;\n  flex: 1;\n  align-items: center;\n  justify-content: space-between;\n  padding: 5px;\n}\n\n.ItkVtkViewer-module_sliderColumn__ZwISb {\n  display: flex;\n  flex-direction: column;\n  flex: 1;\n  padding: 5px;\n}\n\n.ItkVtkViewer-module_mainUIRow__vTXih {\n  justify-content: space-around;\n  max-width: 420px;\n}\n\n.ItkVtkViewer-module_planeUIRow__D5gCh {\n  background: rgba(128, 128, 128, 0.5);\n}\n\n.ItkVtkViewer-module_layersUIRow__0LDm5 {\n  justify-content: space-around;\n  max-width: 420px;\n}\n\n.ItkVtkViewer-module_progress__WydXH {\n  color: white;\n  font-size: 200%;\n  height: 100vh;\n  width: 100vw;\n  text-align: center;\n  vertical-align: middle;\n  line-height: 100vh;\n}\n\n.ItkVtkViewer-module_piecewiseWidget__5gKl5 {\n  flex: 1;\n  background: rgba(255, 255, 255, 0.2);\n  border-radius: 3px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_logo__9ErCF {\n  position: absolute;\n  top: 5px;\n  right: 5px;\n  height: 2.0em;\n  width: 2.0em;\n  cursor: pointer;\n  z-index: 100;\n}\n\n.ItkVtkViewer-module_fpsMonitor__bnwqr {\n  position: absolute;\n  top: 5px;\n  right: 5px;\n  border-radius: 5px;\n  background: rgba(255, 255, 255, 0.6);\n  cursor: pointer;\n  z-index: 101;\n}\n\n[itk-vtk-tooltip] {\n    position: relative;\n}\n[itk-vtk-tooltip]::before {\n    content: attr(itk-vtk-tooltip-content);\n    visibility: hidden;\n    position: absolute;\n    top: 50%;\n    right: calc(100% + 16px);\n    width: 400%;\n    padding: 4px 6px;\n    text-align: center;\n    text-transform: none;\n    font-size: 0.9em;\n    font-family: monospace;\n    border-radius: 3px;\n    background: rgba(0.9, 0.9, 0.9, 0.95);\n    color: white;\n    opacity: 0;\n    transform: translate(15px, -50%);\n    transition-property: all;\n    transition-duration: 0.3s;\n    transition-timing-function: ease-in-out;\n    transition-delay: 0.8s;\n    z-index: 1;\n}\n\n[itk-vtk-tooltip]:hover::before {\n    opacity: 1;\n    visibility: visible;\n    transform: translate(0, -50%);\n}\n\n[itk-vtk-tooltip-bottom]::before {\n    top: calc(100% + 16px);\n    left: 50%;\n    right: initial;\n    transform: translate(-50%, -15px);\n}\n[itk-vtk-tooltip-bottom]:hover::before {\n    transform: translate(-50%, 0)\n}\n[itk-vtk-tooltip-right]::before {\n    top: 50%;\n    left: calc(100% + 16px);\n    right: initial;\n    transform: translate(-15px, -50%);\n}\n[itk-vtk-tooltip-right]:hover::before {\n    transform: translate(0, -50%);\n}\n\n[itk-vtk-tooltip-top-screenshot]::before {\n    top: initial;\n    left: 260%;\n    right: initial;\n    bottom: calc(100% + 8px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-screenshot]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-annotations]::before {\n    top: initial;\n    left: 160%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-annotations]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-axes]::before {\n    top: initial;\n    left: 160%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top-axes]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-fullscreen]::before {\n    top: initial;\n    left: 120%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n    width: 400%;\n}\n[itk-vtk-tooltip-top-fullscreen]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top]::before {\n    top: initial;\n    left: 60%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n}\n[itk-vtk-tooltip-top]:hover::before {\n    transform: translate(-50%, 0);\n}\n[itk-vtk-tooltip-top-fullscreen]::before {\n    top: initial;\n    left: 120%;\n    right: initial;\n    bottom: calc(100% + 10px);\n    transform: translate(-50%, 15px);\n    width: 400%;\n}\n\n.ItkVtkViewer-module_layerEntryCommon__oIE1u {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: stretch;\n  justify-content: space-between;\n  border-style: solid;\n  border-width: 2px;\n  border-radius: 10%;\n}\n\n.ItkVtkViewer-module_layerEntryBrightBG__qXyI2 {\n  border-color: #666;\n}\n\n.ItkVtkViewer-module_layerEntryDarkBG__BmiCj {\n  border-color: #AAA;\n}\n\n.ItkVtkViewer-module_layerLabelCommon__kTiO9 {\n  border: none;\n  background: transparent;\n  font-size: 1.2em;\n  margin-right: 10px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_layerLabelBrightBG__vAfex {\n  color: black;\n}\n\n.ItkVtkViewer-module_layerLabelDarkBG__sM6Bg {\n  color: white;\n}\n\n.ItkVtkViewer-module_visibleButton__ezrIc {\n  flex-basis: 2.5em;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_visibleButton__ezrIc img {\n  height: 1.2em;\n  width: 1.2em;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n}\n\n.ItkVtkViewer-module_layerIcon__v-rxO img {\n  height: 1.2em;\n  width: 1.2em;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 8px;\n  padding-right: 6px;\n}\n\n.ItkVtkViewer-module_tooltipButtonBrightBG__yffVf::before {\n}\n\n.ItkVtkViewer-module_tooltipButtonDarkBG__gEu0i::before {\n  filter: invert(100%);\n  -webkit-filter: invert(100%);\n}\n\n.ItkVtkViewer-module_invertibleButtonBrightBG__VmIfT {\n}\n\n.ItkVtkViewer-module_invertibleButtonDarkBG__GoKgD {\n  filter: invert(100%);\n  -webkit-filter: invert(100%);\n}\n\n.ItkVtkViewer-module_collapseUIButton__Ac6-L {\n  height: 1.5em;\n  width: 1.5em;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_screenshotButton__OL4Na {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_screenshotButton__OL4Na img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_annotationsButton__Msb-p {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_annotationsButton__Msb-p img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_axesButton__k2H6p {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_axesButton__k2H6p img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_fullscreenButton__en3Z5 {\n  flex: 1;\n  width: 8m;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_fullscreenButton__en3Z5 img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_interpolationButton__2P0HJ {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 2px;\n  padding-right: 4px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_interpolationButton__2P0HJ img {\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_cropButton__ljwuU {\n  flex: 1;\n  height: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_cropButton__ljwuU img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_resetCropButton__SCGTH {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_resetCropButton__SCGTH img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_distanceEntry__zXMUS {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: self-start;\n}\n\n.ItkVtkViewer-module_distanceButton__NhxBT {\n  flex: 1;\n  height: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_distanceButton__NhxBT img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_distanceLabelCommon__Ec-uc {\n  border: none;\n  background: transparent;\n  font-size: 1.2em;\n  margin-right: 10px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_distanceLabelBrightBG__aYmfG {\n  color: black;\n}\n\n.ItkVtkViewer-module_distanceLabelDarkBG__kYXvI {\n  color: white;\n}\n\n.ItkVtkViewer-module_distanceInput__gyNaU {\n  background: transparent;\n  color: white;\n  font-size: 1.0em;\n  width: 80px;\n}\n\n.ItkVtkViewer-module_resetCameraButton__l9FGp {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_resetCameraButton__l9FGp img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_bgColorButton__yrjOX {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_bgColorButton__yrjOX img {\n  height: 1.2em;\n  width: 1.2em;\n}\n\n.ItkVtkViewer-module_viewModeButton__OtTng {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 6px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_viewModeButton__OtTng img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n.ItkVtkViewer-module_shadowButton__09fEk {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 0px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_shadowButton__09fEk img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n\n.ItkVtkViewer-module_viewPlanesButton__rSnuZ {\n  flex: 1;\n  width: 8mm;\n  padding-top: 2px;\n  padding-bottom: 2px;\n  padding-left: 0px;\n  padding-right: 6px;\n  cursor: pointer;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_viewPlanesButton__rSnuZ img {\n  width: 1.3em;\n  height: 1.3em;\n}\n\n.ItkVtkViewer-module_toggleInput__jHLTo {\n  margin: 0px;\n  width: 0;\n  opacity: 0;\n  box-sizing: content-box;\n}\n\n.ItkVtkViewer-module_toggleButton__qHhHZ {\n  cursor: pointer;\n  border-radius: 0.2em;\n  opacity: 0.45;\n}\n\ninput:checked.ItkVtkViewer-module_toggleInput__jHLTo + label {\n  opacity: 1.0;\n}\n\n.ItkVtkViewer-module_cinematicButton__JzsCj {\n  margin-left: 6px;\n}\n\n.ItkVtkViewer-module_numberInput__pDxYH {\n  color: white;\n  background: transparent;\n  font-size: 1.0em;\n  padding-left: 2px;\n  width: 70px;\n}\n\n.ItkVtkViewer-module_selector__yw8l- {\n  display: flex;\n  direction: row;\n  font-size: 1.2em;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF {\n  position: absolute;\n  opacity: 0;\n  pointer-events: none;\n}\n\n.ItkVtkViewer-module_disableInterface__CGB4S {\n  pointer-events: none;\n  opacity: 0.5;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(40, 40, 40, 0.5);\n  padding: 5px;\n  margin-right: 2px;\n  border-radius: 5px 5px 0px 0px;\n  color: #777;\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF:hover + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(90, 90, 90, 0.5);\n}\n\n.ItkVtkViewer-module_componentTab__6KSJF:checked + .ItkVtkViewer-module_compTabLabel__8u4iU {\n  background: rgba(127, 127, 127, 0.5);\n  color: #FFF;\n}\n\n.ItkVtkViewer-module_componentVisibility__y1rRS {\n  position: relative;\n  top: -2px;\n  margin-left: 10px;\n}\n\nselect {\n  -moz-appearance: none;\n}\n\nselect option {\n  color: black;\n}\n\nselect:focus {\n  outline: none;\n  border: none;\n}\n\n.ItkVtkViewer-module_sampleDistanceButton__NjT0o {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 6px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_sampleDistanceButton__NjT0o img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_blendModeButton__cit1w {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 8px;\n  padding-right: 0px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_blendModeButton__cit1w img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_gradientOpacitySlider__wkEqP {\n  width: 8mm;\n  padding: 4px;\n  padding-left: 6px;\n  padding-right: 0px;\n  z-index: 1000;\n}\n\n.ItkVtkViewer-module_gradientOpacitySlider__wkEqP img {\n  width: 1.2em;\n  height: 1.2em;\n}\n\n.ItkVtkViewer-module_sliderEntry__3r3gO {\n  flex: 1;\n  display: flex;\n  flex-direction: row;\n  align-items: center;\n}\n\n.ItkVtkViewer-module_slider__eT9qm {\n  flex: 1;\n  min-height: 1rem;\n}\n\n.ItkVtkViewer-module_planeLabel__E1zOk {\n  padding-left: 6px;\n  padding: 2px;\n  display: block;\n  font-size: 1.1em;\n  font-family: monospace;\n  color: black;\n  border-width: 2px;\n  border-radius: 10%;\n}\n\n.ItkVtkViewer-module_xPlaneLabel__wK4Cb {\n  background-color: #ef5350;\n}\n\n.ItkVtkViewer-module_yPlaneLabel__rIm0j {\n  background-color: #fdd835;\n}\n\n.ItkVtkViewer-module_zPlaneLabel__94NL7 {\n  background-color: #4caf50;\n}\n\n.ItkVtkViewer-module_gradientOpacityScale__NrqOZ {\n  z-index: 1100;\n  position: relative;\n}\n\n.ItkVtkViewer-module_gradientOpacityScale__NrqOZ input {\n  position: absolute;\n  bottom: 20px;\n  left: -24px;\n  width: 12px;\n  -ms-writing-mode: bt-lr;\n      writing-mode: bt-lr;\n  -webkit-appearance: slider-vertical;\n}\n\n.ItkVtkViewer-module_bigFileDrop__cZdkP {\n  position: absolute;\n  left: 50%;\n  top: 50%;\n  transform: translate(-50%, -50%);\n  background-color: white;\n  background-image: url('./dropBG.jpg');\n  background-repeat: no-repeat;\n  background-position: center;\n  background-size: contain;\n  border-radius: 10px;\n  width: 50px;\n  padding: calc(50vh - 2em) calc(50vw - 25px - 2em);\n}\n\n.ItkVtkViewer-module_fullscreenContainer__-H3c8 {\n  position: absolute;\n  width: 100vw;\n  height: 100vh;\n  top: 0;\n  left: 0;\n  overflow: hidden;\n  background: black;\n  margin: 0;\n  padding: 0;\n}\n"
 var style = {
   loading: 'ItkVtkViewer-module_loading__11c63',
   spin: 'ItkVtkViewer-module_spin__mT5S6',
@@ -36,6 +36,7 @@ var style = {
   uiContainer: 'ItkVtkViewer-module_uiContainer__CiawP',
   uiGroup: 'ItkVtkViewer-module_uiGroup__ad-WI',
   uiRow: 'ItkVtkViewer-module_uiRow__KTQa8',
+  sliderColumn: 'ItkVtkViewer-module_sliderColumn__ZwISb',
   mainUIRow:
     'ItkVtkViewer-module_mainUIRow__vTXih ItkVtkViewer-module_uiRow__KTQa8',
   planeUIRow:
@@ -80,6 +81,7 @@ var style = {
   viewPlanesButton: 'ItkVtkViewer-module_viewPlanesButton__rSnuZ',
   toggleInput: 'ItkVtkViewer-module_toggleInput__jHLTo',
   toggleButton: 'ItkVtkViewer-module_toggleButton__qHhHZ',
+  cinematicButton: 'ItkVtkViewer-module_cinematicButton__JzsCj',
   numberInput: 'ItkVtkViewer-module_numberInput__pDxYH',
   selector: 'ItkVtkViewer-module_selector__yw8l-',
   componentTab: 'ItkVtkViewer-module_componentTab__6KSJF',
@@ -4240,8 +4242,146 @@ function createBlendModeSelector(context, uiContainer) {
   uiContainer.appendChild(blendModeSelector)
 }
 
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  } else {
+    obj[key] = value
+  }
+
+  return obj
+}
+
+var toggleCinematicInput, toggleContainer
+var sliderMap = new Map()
+
+function makeSlider(context, label, parameterName, _ref) {
+  var min = _ref.min,
+    max = _ref.max,
+    step = _ref.step,
+    start = _ref.start
+  var container = document.createElement('div')
+  container.setAttribute('class', style.sliderEntry)
+  container.innerHTML = '\n    <label itk-vtk-tooltip itk-vtk-tooltip-top-screenshot itk-vtk-tooltip-content=" '
+    .concat(label, '">\n      ')
+    .concat(label, '\n    </label>\n    <input type="range" min="')
+    .concat(min, '" max="')
+    .concat(max, '" step="')
+    .concat(step, '" value="')
+    .concat(start, '" \n      class="')
+    .concat(style.slider, '" />')
+  var slider = container.children[1]
+  slider.addEventListener('input', function(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    context.service.send({
+      type: 'SET_CINEMATIC_PARAMETERS',
+      data: {
+        name: context.images.selectedName,
+        params: _defineProperty({}, parameterName, Number(slider.value)),
+      },
+    })
+  })
+  sliderMap.set(parameterName, slider)
+  return container
+}
+
+function createCinematicParameters(context, toggleParent, rowParent) {
+  var toggleButton = document.createElement('div')
+  toggleButton.innerHTML = '<input id="'
+    .concat(context.id, '-toggleCinematicButton" type="checkbox" class="')
+    .concat(
+      style.toggleInput,
+      '"><label itk-vtk-tooltip itk-vtk-tooltip-top-screenshot itk-vtk-tooltip-content="Toggle Cinematic" class="'
+    )
+    .concat(style.interpolationButton, ' ')
+    .concat(style.toggleButton, ' ')
+    .concat(style.cinematicButton, '" for="')
+    .concat(context.id, '-cinemanticButton"><img src="')
+    .concat(optimizedSVGDataUri$k, '" alt="cinemantic" /></label>')
+  toggleCinematicInput = toggleButton.children[0]
+  toggleButton.addEventListener('click', function(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    var _context$images$actor = context.images.actorContext.get(
+        context.images.selectedName
+      ),
+      isCinematicOn = _context$images$actor.cinematicParameters.isCinematicOn
+
+    context.service.send({
+      type: 'SET_CINEMATIC_PARAMETERS',
+      data: {
+        name: context.images.selectedName,
+        params: {
+          isCinematicOn: !isCinematicOn,
+        },
+      },
+    })
+  })
+  toggleParent.appendChild(toggleButton) // hidable sliders
+
+  var row = document.createElement('div')
+  toggleContainer = document.createElement('div')
+  toggleContainer.setAttribute('class', style.sliderColumn)
+  row.appendChild(toggleContainer)
+  rowParent.appendChild(row)
+  context.images.volumeUiElements.push(row)
+  toggleContainer.style.flexDirection = 'column'
+  toggleContainer.style.display = 'none'
+  toggleContainer.appendChild(
+    makeSlider(context, 'Local Ambient Occlusion Kernel', 'laoKernelSize', {
+      min: 5,
+      max: 32,
+      step: 1,
+      start: 5,
+    })
+  )
+  toggleContainer.appendChild(
+    makeSlider(context, 'Local Ambient Occlusion Radius', 'laoKernelRadius', {
+      min: 1,
+      max: 32,
+      step: 1,
+      start: 1,
+    })
+  )
+  toggleContainer.appendChild(
+    makeSlider(context, 'Diffuse', 'diffuse', {
+      min: 0,
+      max: 2,
+      step: 2 / 100,
+      start: 1,
+    })
+  )
+  toggleContainer.appendChild(
+    makeSlider(context, 'Ambient', 'ambient', {
+      min: 0,
+      max: 1,
+      step: 1 / 100,
+      start: 0.4,
+    })
+  )
+}
+function applyCinematicChanged(context, _ref2) {
+  var actorContext = _ref2.actorContext
+  var cinematicParameters = actorContext.cinematicParameters
+  toggleCinematicInput.checked = cinematicParameters.isCinematicOn
+  toggleContainer.style.display = cinematicParameters.isCinematicOn
+    ? 'flex'
+    : 'none'
+  ;['laoKernelSize', 'laoKernelRadius', 'diffuse', 'ambient'].forEach(function(
+    param
+  ) {
+    sliderMap.get(param).value = cinematicParameters[param]
+  })
+}
+
 function createVolumeRenderingInputs(context, imagesUIGroup) {
-  context.id
   var volumeRow1 = document.createElement('div')
   volumeRow1.setAttribute('class', style.uiRow)
   createShadowToggle(context, volumeRow1)
@@ -4253,8 +4393,8 @@ function createVolumeRenderingInputs(context, imagesUIGroup) {
   createSampleDistanceSlider(context, volumeRow2)
   createBlendModeSelector(context, volumeRow2)
   imagesUIGroup.appendChild(volumeRow2)
-  context.images.volumeRow1 = volumeRow1
-  context.images.volumeRow2 = volumeRow2
+  context.images.volumeUiElements = [volumeRow1, volumeRow2]
+  createCinematicParameters(context, volumeRow2, imagesUIGroup)
 }
 
 var CategoricalPresetIcons = new Map()
@@ -4879,8 +5019,9 @@ function updateImageInterface(context) {
 
   if (image) {
     if (image.imageType.dimension === 3) {
-      context.images.volumeRow1.style.display = 'flex'
-      context.images.volumeRow2.style.display = 'flex'
+      context.images.volumeUiElements.forEach(function(e) {
+        return (e.style.display = 'flex')
+      })
 
       if (context.main.xPlaneRow) {
         context.main.xPlaneRow.style.display = 'flex'
@@ -4888,8 +5029,9 @@ function updateImageInterface(context) {
         context.main.zPlaneRow.style.display = 'flex'
       }
     } else {
-      context.images.volumeRow1.style.display = 'none'
-      context.images.volumeRow2.style.display = 'none'
+      context.images.volumeUiElements.forEach(function(e) {
+        return (e.style.display = 'none')
+      })
 
       if (context.main.xPlaneRow) {
         context.main.xPlaneRow.style.display = 'none'
@@ -5300,6 +5442,7 @@ var imagesUIMachineOptions = {
     applyGradientOpacityScale: applyGradientOpacityScale,
     applyVolumeSampleDistance: applyVolumeSampleDistance,
     applyBlendMode: applyBlendMode,
+    applyCinematicChanged: applyCinematicChanged,
     applyHistogram: applyHistogram,
     applyLookupTable: applyLookupTable,
     applyLabelImageBlend: applyLabelImageBlend,

--- a/src/UI/reference-ui/package.json
+++ b/src/UI/reference-ui/package.json
@@ -5,6 +5,7 @@
   "module": "dist/referenceUIMachineOptions.js",
   "scripts": {
     "build": "rollup -c rollup.config.js",
+    "dev": "rollup -w -c rollup.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/UI/reference-ui/src/Images/cinematic.js
+++ b/src/UI/reference-ui/src/Images/cinematic.js
@@ -1,0 +1,118 @@
+import { interpolationIconDataUri } from 'itk-viewer-icons'
+import style from '../ItkVtkViewer.module.css'
+
+let toggleCinematicInput, toggleContainer
+
+const sliderMap = new Map()
+
+function makeSlider(context, label, parameterName, { min, max, step, start }) {
+  const container = document.createElement('div')
+  container.setAttribute('class', style.sliderEntry)
+  container.innerHTML = `
+    <label itk-vtk-tooltip itk-vtk-tooltip-top-screenshot itk-vtk-tooltip-content=" ${label}">
+      ${label}
+    </label>
+    <input type="range" min="${min}" max="${max}" step="${step}" value="${start}" 
+      class="${style.slider}" />`
+  const slider = container.children[1]
+  slider.addEventListener('input', event => {
+    event.preventDefault()
+    event.stopPropagation()
+    context.service.send({
+      type: 'SET_CINEMATIC_PARAMETERS',
+      data: {
+        name: context.images.selectedName,
+        params: { [parameterName]: Number(slider.value) },
+      },
+    })
+  })
+
+  sliderMap.set(parameterName, slider)
+
+  return container
+}
+
+export function createCinematicParameters(context, toggleParent, rowParent) {
+  const toggleButton = document.createElement('div')
+
+  toggleButton.innerHTML = `<input id="${context.id}-toggleCinematicButton" type="checkbox" class="${style.toggleInput}"><label itk-vtk-tooltip itk-vtk-tooltip-top-screenshot itk-vtk-tooltip-content="Toggle Cinematic" class="${style.interpolationButton} ${style.toggleButton} ${style.cinematicButton}" for="${context.id}-cinemanticButton"><img src="${interpolationIconDataUri}" alt="cinemantic" /></label>`
+  toggleCinematicInput = toggleButton.children[0]
+
+  toggleButton.addEventListener('click', event => {
+    event.preventDefault()
+    event.stopPropagation()
+    const {
+      cinematicParameters: { isCinematicOn },
+    } = context.images.actorContext.get(context.images.selectedName)
+    context.service.send({
+      type: 'SET_CINEMATIC_PARAMETERS',
+      data: {
+        name: context.images.selectedName,
+        params: { isCinematicOn: !isCinematicOn },
+      },
+    })
+  })
+
+  toggleParent.appendChild(toggleButton)
+
+  // hidable sliders
+  const row = document.createElement('div')
+
+  toggleContainer = document.createElement('div')
+  toggleContainer.setAttribute('class', style.sliderColumn)
+  row.appendChild(toggleContainer)
+  rowParent.appendChild(row)
+
+  context.images.volumeUiElements.push(row)
+
+  toggleContainer.style.flexDirection = 'column'
+  toggleContainer.style.display = 'none'
+
+  toggleContainer.appendChild(
+    makeSlider(context, 'Local Ambient Occlusion Kernel', 'laoKernelSize', {
+      min: 5,
+      max: 32,
+      step: 1,
+      start: 5,
+    })
+  )
+
+  toggleContainer.appendChild(
+    makeSlider(context, 'Local Ambient Occlusion Radius', 'laoKernelRadius', {
+      min: 1,
+      max: 32,
+      step: 1,
+      start: 1,
+    })
+  )
+
+  toggleContainer.appendChild(
+    makeSlider(context, 'Diffuse', 'diffuse', {
+      min: 0,
+      max: 2,
+      step: 2 / 100,
+      start: 1,
+    })
+  )
+
+  toggleContainer.appendChild(
+    makeSlider(context, 'Ambient', 'ambient', {
+      min: 0,
+      max: 1,
+      step: 1 / 100,
+      start: 0.4,
+    })
+  )
+}
+
+export function applyCinematicChanged(context, { actorContext }) {
+  const { cinematicParameters } = actorContext
+
+  toggleCinematicInput.checked = cinematicParameters.isCinematicOn
+  toggleContainer.style.display = cinematicParameters.isCinematicOn
+    ? 'flex'
+    : 'none'
+  ;['laoKernelSize', 'laoKernelRadius', 'diffuse', 'ambient'].forEach(param => {
+    sliderMap.get(param).value = cinematicParameters[param]
+  })
+}

--- a/src/UI/reference-ui/src/Images/createSampleDistanceSlider.js
+++ b/src/UI/reference-ui/src/Images/createSampleDistanceSlider.js
@@ -1,5 +1,3 @@
-import macro from '@kitware/vtk.js/macro'
-
 import style from '../ItkVtkViewer.module.css'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 

--- a/src/UI/reference-ui/src/Images/createVolumeRenderingInputs.js
+++ b/src/UI/reference-ui/src/Images/createVolumeRenderingInputs.js
@@ -4,10 +4,9 @@ import createShadowToggle from './createShadowToggle'
 import createGradientOpacitySlider from './createGradientOpacitySlider'
 import createSampleDistanceSlider from './createSampleDistanceSlider'
 import createBlendModeSelector from './createBlendModeSelector'
+import { createCinematicParameters } from './cinematic'
 
 function createVolumeRenderingInputs(context, imagesUIGroup) {
-  const viewerDOMId = context.id
-
   const volumeRow1 = document.createElement('div')
   volumeRow1.setAttribute('class', style.uiRow)
   createShadowToggle(context, volumeRow1)
@@ -21,8 +20,9 @@ function createVolumeRenderingInputs(context, imagesUIGroup) {
   createBlendModeSelector(context, volumeRow2)
   imagesUIGroup.appendChild(volumeRow2)
 
-  context.images.volumeRow1 = volumeRow1
-  context.images.volumeRow2 = volumeRow2
+  context.images.volumeUiElements = [volumeRow1, volumeRow2]
+
+  createCinematicParameters(context, volumeRow2, imagesUIGroup)
 }
 
 export default createVolumeRenderingInputs

--- a/src/UI/reference-ui/src/Images/imagesUIMachineOptions.js
+++ b/src/UI/reference-ui/src/Images/imagesUIMachineOptions.js
@@ -22,6 +22,7 @@ import applyLabelNames from './applyLabelNames'
 import applySelectedLabel from './applySelectedLabel'
 import scaleSelector from './scaleSelector'
 import { applyPiecewiseFunctionPointsToEditor } from './createTransferFunctionWidget'
+import { applyCinematicChanged } from './cinematic'
 
 const imagesUIMachineOptions = {
   actions: {
@@ -46,6 +47,8 @@ const imagesUIMachineOptions = {
     applyGradientOpacityScale,
     applyVolumeSampleDistance,
     applyBlendMode,
+    applyCinematicChanged,
+
     applyHistogram,
 
     applyLookupTable,

--- a/src/UI/reference-ui/src/Images/updateImageInterface.js
+++ b/src/UI/reference-ui/src/Images/updateImageInterface.js
@@ -28,16 +28,14 @@ function updateImageInterface(context) {
 
   if (image) {
     if (image.imageType.dimension === 3) {
-      context.images.volumeRow1.style.display = 'flex'
-      context.images.volumeRow2.style.display = 'flex'
+      context.images.volumeUiElements.forEach(e => (e.style.display = 'flex'))
       if (context.main.xPlaneRow) {
         context.main.xPlaneRow.style.display = 'flex'
         context.main.yPlaneRow.style.display = 'flex'
         context.main.zPlaneRow.style.display = 'flex'
       }
     } else {
-      context.images.volumeRow1.style.display = 'none'
-      context.images.volumeRow2.style.display = 'none'
+      context.images.volumeUiElements.forEach(e => (e.style.display = 'none'))
       if (context.main.xPlaneRow) {
         context.main.xPlaneRow.style.display = 'none'
         context.main.yPlaneRow.style.display = 'none'

--- a/src/UI/reference-ui/src/ItkVtkViewer.module.css
+++ b/src/UI/reference-ui/src/ItkVtkViewer.module.css
@@ -56,6 +56,13 @@
   padding: 5px;
 }
 
+.sliderColumn {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 5px;
+}
+
 .mainUIRow {
   composes: uiRow;
   justify-content: space-around;
@@ -380,7 +387,6 @@
 }
 
 .interpolationButton img {
-  height: 1.2em;
   width: 1.2em;
 }
 
@@ -542,7 +548,7 @@
 
 .toggleInput {
   margin: 0px;
-  width: 0%;
+  width: 0;
   opacity: 0;
   box-sizing: content-box;
 }
@@ -555,6 +561,10 @@
 
 input:checked.toggleInput + label {
   opacity: 1.0;
+}
+
+.cinematicButton {
+  margin-left: 6px;
 }
 
 .numberInput {
@@ -667,7 +677,6 @@ select:focus {
 .slider {
   flex: 1;
   min-height: 1rem;
-  width: 5px;
 }
 
 .planeLabel {

--- a/src/createViewerMachine.js
+++ b/src/createViewerMachine.js
@@ -313,6 +313,12 @@ const createViewerMachine = (options, context, eventEmitterCallback) => {
             SET_IMAGE_SCALE: {
               actions: forwardTo('rendering'),
             },
+            SET_CINEMATIC_PARAMETERS: {
+              actions: forwardTo('rendering'),
+            },
+            CINEMATIC_CHANGED: {
+              actions: [forwardTo('ui'), forwardTo('rendering')],
+            },
             REQUEST_ANIMATION: {
               actions: forwardTo('rendering'),
             },


### PR DESCRIPTION
Adds a toggle button that enables Cinematic Volume Rendering and shows sliders.

Good tests:
`http://localhost:8082/?image=test-data/ome-ngff-prototypes/single_image/v0.4/zyx.ome.zarr`
and 
`http://localhost:8082/?image=test-data/HeadMRVolume.nrrd`

closes #536

- [ ] Viewer API for all parameters


![image](https://user-images.githubusercontent.com/16823231/192886313-8a6f772e-981c-46e1-92f7-9251c96f9f6c.png)

