### PR TITLE
ci(Data): Use tarball for CI fetch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,33 +20,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Download testing data
+        shell: bash
+        run: |
+          curl -OL https://github.com/Kitware/itk-vtk-viewer/releases/download/v14.5.0/itk-vtk-viewer-testing-data.tar.gz
+          tar xvzf ./itk-vtk-viewer-testing-data.tar.gz -C test/
+
       - name: Build
         run: npm run build
-
-      - name: Setup ipfs
-        uses: ibnesayeed/setup-ipfs@master
-        with:
-          ipfs_version: ^0.12
-      - name: Connect to ipfs peers with our data
-        shell: bash
-        run: |
-          export MSYS_NO_PATHCONV=1
-          # web3.storage
-          ipfs swarm connect /ip4/139.178.69.155/tcp/4001/p2p/12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1
-          ipfs swarm connect /ip4/139.178.68.91/tcp/4001/p2p/12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK
-          ipfs swarm connect /ip4/147.75.33.191/tcp/4001/p2p/12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW
-          ipfs swarm connect /ip4/147.75.32.73/tcp/4001/p2p/12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj
-          ipfs swarm connect /ip4/145.40.89.195/tcp/4001/p2p/12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU
-          ipfs swarm connect /ip4/136.144.56.153/tcp/4001/p2p/12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ
-          # pinata.cloud
-          ipfs swarm connect /dnsaddr/nyc1-1.hostnodes.pinata.cloud/p2p/QmRjLSisUCHVpFa5ELVvX3qVPfdxajxWJEHs9kN3EcxAW6
-          ipfs swarm connect /dnsaddr/nyc1-2.hostnodes.pinata.cloud/p2p/QmPySsdmbczdZYBpbi2oq2WMJ8ErbfxtkG8Mo192UHkfGP
-          ipfs swarm connect /dnsaddr/nyc1-3.hostnodes.pinata.cloud/p2p/QmSarArpxemsPESa6FNkmuu9iSE1QWqPX2R3Aw6f5jq4D5
-      - name: Pin ipfs testing data locally
-        shell: bash
-        run: |
-          cid=$(grep 'IPFS_CID =' test/downloadData.mjs | cut -d ' ' -f 4 | tr -d "'")
-          ipfs get -o ./test/data -- $cid
 
       - name: Test
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,38 +17,21 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
+
       - name: Install dependencies
         run: |
           npm ci
           sudo apt-get install xvfb
 
-      - name: Setup ipfs
-        uses: ibnesayeed/setup-ipfs@master
-        with:
-          ipfs_version: ^0.12
-      - name: Connect to ipfs peers with our data
+      - name: Download testing data
         shell: bash
         run: |
-          export MSYS_NO_PATHCONV=1
-          # web3.storage
-          ipfs swarm connect /ip4/139.178.69.155/tcp/4001/p2p/12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1
-          ipfs swarm connect /ip4/139.178.68.91/tcp/4001/p2p/12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK
-          ipfs swarm connect /ip4/147.75.33.191/tcp/4001/p2p/12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW
-          ipfs swarm connect /ip4/147.75.32.73/tcp/4001/p2p/12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj
-          ipfs swarm connect /ip4/145.40.89.195/tcp/4001/p2p/12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU
-          ipfs swarm connect /ip4/136.144.56.153/tcp/4001/p2p/12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ
-          # pinata.cloud
-          ipfs swarm connect /dnsaddr/nyc1-1.hostnodes.pinata.cloud/p2p/QmRjLSisUCHVpFa5ELVvX3qVPfdxajxWJEHs9kN3EcxAW6
-          ipfs swarm connect /dnsaddr/nyc1-2.hostnodes.pinata.cloud/p2p/QmPySsdmbczdZYBpbi2oq2WMJ8ErbfxtkG8Mo192UHkfGP
-          ipfs swarm connect /dnsaddr/nyc1-3.hostnodes.pinata.cloud/p2p/QmSarArpxemsPESa6FNkmuu9iSE1QWqPX2R3Aw6f5jq4D5
-      - name: Pin ipfs testing data locally
-        shell: bash
-        run: |
-          cid=$(grep 'IPFS_CID =' test/downloadData.mjs | cut -d ' ' -f 4 | tr -d "'")
-          ipfs get -o ./test/data -- $cid
+          curl -OL https://github.com/Kitware/itk-vtk-viewer/releases/download/v14.5.0/itk-vtk-viewer-testing-data.tar.gz
+          tar xvzf ./itk-vtk-viewer-testing-data.tar.gz -C test/
 
       - name: Build
         run: npm run build
+
       - name: Chrome and Firefox tests
         run: |
           # Failing based on vtk.js piecewisegaussian?


### PR DESCRIPTION
The IPFS node has difficulty downloading the data without a timeout.
This may be due to starting up the node and immediately requesting large
amounts of data without the opportunity to provide data to peers.

Download and extract a versioned tarball for now from GitHub Releases.

In the future, we will look to download a versioned, provenance rich
DataLad dataset.
