### PR TITLE
fix(croppingPlanes): disable picking on volume actor

### DIFF
--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -7,6 +7,7 @@ import applyLabelImageBlend from './applyLabelImageBlend'
 import applyVolumeSampleDistance from './applyVolumeSampleDistance'
 import {
   addCroppingPlanes,
+  makeCroppable,
   updateCroppingParametersFromImage,
 } from '../Main/croppingPlanes'
 
@@ -47,6 +48,8 @@ function applyRenderedImage(context, event) {
       context.itkVtkView
     )
     const { representationProxy } = context.images
+
+    makeCroppable(representationProxy)
 
     if (context.use2D) {
       context.itkVtkView.setViewMode('ZPlane')

--- a/src/Rendering/VTKJS/Main/croppingPlanes.js
+++ b/src/Rendering/VTKJS/Main/croppingPlanes.js
@@ -218,3 +218,8 @@ export function addCroppingPlanes(context, actor) {
     mapper.addClippingPlane(plane)
   })
 }
+
+export function makeCroppable(representationProxy) {
+  // allows for grabbing crop handles on the other side of volume
+  representationProxy.getVolumes().forEach(v => v.setPickable(false))
+}


### PR DESCRIPTION
Allows for grabbing of crop plane handles "through" the volume bounding box.  

Sad effect is can click on handles even if they are totally occluded by the volume!

Alternatives:
- change appearance of handles when on other side of volume
- fix vtk.js picking (click through volume opacity threshold?)