### PR TITLE
fix(createImageRenderingActor): handle errors making new image scale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "itk-image-io": "^1.0.0-b.15",
         "itk-mesh-io": "^1.0.0-b.15",
         "itk-viewer-icons": "^11.12.0",
-        "itk-viewer-transfer-function-editor": "^1.1.3",
+        "itk-viewer-transfer-function-editor": "^1.1.4",
         "itk-wasm": "^1.0.0-b.17",
         "mobx": "^5.15.7",
         "mousetrap": "^1.6.5",
@@ -12417,9 +12417,9 @@
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
     "node_modules/itk-viewer-transfer-function-editor": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.3.tgz",
-      "integrity": "sha512-z7j2dNb9IgKz97oDaXd/smB69ttuxLQFQu8FviQRcXasZ/nK1TWqzxGxByPh41RCKdxDPNtL6XYN1KkhYqhu/g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.4.tgz",
+      "integrity": "sha512-1qWJcKdIXbzY9SXrz5ukN3DxkpXB8WTzuRh4HD+kO1WFw2RUJygcxCP3dtQIDiAYXfu0dh1GHZ88SbDdnzxJcg=="
     },
     "node_modules/itk-wasm": {
       "version": "1.0.0-b.17",
@@ -34387,9 +34387,9 @@
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
     "itk-viewer-transfer-function-editor": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.3.tgz",
-      "integrity": "sha512-z7j2dNb9IgKz97oDaXd/smB69ttuxLQFQu8FviQRcXasZ/nK1TWqzxGxByPh41RCKdxDPNtL6XYN1KkhYqhu/g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.4.tgz",
+      "integrity": "sha512-1qWJcKdIXbzY9SXrz5ukN3DxkpXB8WTzuRh4HD+kO1WFw2RUJygcxCP3dtQIDiAYXfu0dh1GHZ88SbDdnzxJcg=="
     },
     "itk-wasm": {
       "version": "1.0.0-b.17",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "itk-image-io": "^1.0.0-b.15",
     "itk-mesh-io": "^1.0.0-b.15",
     "itk-viewer-icons": "^11.12.0",
-    "itk-viewer-transfer-function-editor": "^1.1.3",
+    "itk-viewer-transfer-function-editor": "^1.1.4",
     "itk-wasm": "^1.0.0-b.17",
     "mobx": "^5.15.7",
     "mousetrap": "^1.6.5",

--- a/src/Context/ImageActorContext.js
+++ b/src/Context/ImageActorContext.js
@@ -2,8 +2,11 @@ class ImageActorContext {
   // MultiscaleSpatialImage to be visualized
   image = null
 
-  // The rendered image / label image scale
+  // The target image scale
   renderedScale = null
+
+  // The successfully loaded scale
+  loadedScale = null
 
   // Automatically adjust the rendered scale
   isFramerateScalePickingOn = true

--- a/src/Context/ImageActorContext.js
+++ b/src/Context/ImageActorContext.js
@@ -3,7 +3,7 @@ class ImageActorContext {
   image = null
 
   // The target image scale
-  renderedScale = null
+  targetScale = null
 
   // The successfully loaded scale
   loadedScale = null

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -20,7 +20,7 @@ const assignHigherScale = assign({
   images: context => {
     const images = context.images
     const actorContext = images.actorContext.get(images.updateRenderedName)
-    actorContext.renderedScale--
+    actorContext.targetScale--
     return images
   },
 })
@@ -35,17 +35,17 @@ const assignLowerScale = assign({
     } else if (actorContext.labelImage) {
       lowestScale = actorContext.labelImage.lowestScale
     }
-    if (actorContext.renderedScale < lowestScale) {
-      actorContext.renderedScale++
+    if (actorContext.targetScale < lowestScale) {
+      actorContext.targetScale++
     }
     return images
   },
 })
 
-const assignRenderedScale = assign({
-  images: ({ images }, { renderedScale }) => {
+const assignTargetScale = assign({
+  images: ({ images }, { targetScale }) => {
     const actorContext = images.actorContext.get(images.updateRenderedName)
-    actorContext.renderedScale = renderedScale
+    actorContext.targetScale = targetScale
     return images
   },
 })
@@ -66,14 +66,14 @@ function highestScaleOrScaleJustRight(context, event, condMeta) {
     context.images.updateRenderedName
   )
 
-  if (actorContext.renderedScale === 0) {
+  if (actorContext.targetScale === 0) {
     return true
   }
 
   let image = actorContext.image ?? actorContext.labelImage
 
   // is voxels count of next scale too much
-  const nextScale = actorContext.renderedScale - 1
+  const nextScale = actorContext.targetScale - 1
   const voxelCount = ['x', 'y', 'z']
     .map(dim => image.scaleInfo[nextScale].arrayShape.get(dim))
     .reduce((voxels, dimSize) => voxels * dimSize, 1)
@@ -285,7 +285,7 @@ const createImageRenderingActor = (options, context /*, event*/) => {
           },
         },
         setImageScale: {
-          entry: assignRenderedScale,
+          entry: assignTargetScale,
           invoke: {
             id: 'updateRenderedImageSetImageScale',
             src: 'updateRenderedImage',

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -361,11 +361,13 @@ function applyRenderedImage(context, event) {
     })
   }
 
-  if (actorContext.renderedScale === 0) {
+  const loadedImage = actorContext.image ?? actorContext.labelImage
+  const hasOneScale = loadedImage.scaleInfo.length === 1
+  if (hasOneScale) {
     context.itkVtkView.setSeCornerAnnotation(ANNOTATION_DEFAULT)
   } else {
     context.itkVtkView.setSeCornerAnnotation(
-      `${ANNOTATION_CUSTOM_PREFIX}<td style="margin-left: 0; margin-right: auto;">${actorContext.renderedScale}</td>${ANNOTATION_CUSTOM_POSTFIX}`
+      `${ANNOTATION_CUSTOM_PREFIX}<td style="margin-left: 0; margin-right: auto;">${actorContext.loadedScale}</td>${ANNOTATION_CUSTOM_POSTFIX}`
     )
   }
 

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -60,11 +60,6 @@ const imagesRenderingMachineOptions = {
       applyLabelNames,
       applyLabelImageWeights,
       applySelectedLabel,
-      updateIsFramerateScalePickingOn: ({ images }, event) => {
-        images.actorContext.get(
-          images.updateRenderedName
-        ).isFramerateScalePickingOn = event.type !== 'SET_IMAGE_SCALE'
-      },
     },
 
     guards: {

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -41,16 +41,14 @@ async function updateRenderedImage(context) {
     return
   }
 
-  const { renderedScale } = actorContext
+  const { targetScale } = actorContext
 
   const boundsToLoad = context.main.areCroppingPlanesTouched
     ? computeRenderedBounds(context)
     : undefined // if not touched, keep growing bounds to fit whole image
 
   const [imageAtScale, labelAtScale] = await Promise.all(
-    [image, labelImage].map(image =>
-      image?.getImage(renderedScale, boundsToLoad)
-    )
+    [image, labelImage].map(image => image?.getImage(targetScale, boundsToLoad))
   )
 
   if (labelAtScale) updateContextWithLabelImage(actorContext, labelAtScale)
@@ -115,7 +113,7 @@ async function updateRenderedImage(context) {
   context.service.send({
     type: 'RENDERED_IMAGE_ASSIGNED',
     data: name,
-    loadedScale: renderedScale,
+    loadedScale: targetScale,
   })
 }
 

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -52,6 +52,7 @@ async function updateRenderedImage(context) {
       image?.getImage(renderedScale, boundsToLoad)
     )
   )
+
   if (labelAtScale) updateContextWithLabelImage(actorContext, labelAtScale)
 
   const isFuseNeeded =
@@ -111,7 +112,11 @@ async function updateRenderedImage(context) {
     fusedImageScalars.setRange(range, comp)
   )
 
-  context.service.send({ type: 'RENDERED_IMAGE_ASSIGNED', data: name })
+  context.service.send({
+    type: 'RENDERED_IMAGE_ASSIGNED',
+    data: name,
+    loadedScale: renderedScale,
+  })
 }
 
 export default updateRenderedImage

--- a/src/Rendering/VTKJS/Main/croppingPlanes.js
+++ b/src/Rendering/VTKJS/Main/croppingPlanes.js
@@ -26,7 +26,7 @@ export function getBoundsOfFullImage({ images }) {
   if (!imageActorContext) return [...vtkBoundingBox.INIT_BOUNDS]
 
   const multiScale = imageActorContext.image ?? imageActorContext.labelImage
-  return multiScale.getWorldBounds(imageActorContext.renderedScale)
+  return multiScale.getWorldBounds(imageActorContext.targetScale)
 }
 
 export function createCropping(context) {

--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -351,7 +351,7 @@ function createImagesUIMachine(options, context) {
               actions: [assignBlendMode, 'applyBlendMode'],
             },
             IMAGE_HISTOGRAM_UPDATED: {
-              actions: ['applyHistogram', forwardTo('scaleSelector')],
+              actions: ['applyHistogram'],
             },
             LABEL_IMAGE_ASSIGNED: {
               actions: ['updateLabelImageInterface'],

--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -290,6 +290,9 @@ function createImagesUIMachine(options, context) {
                 forwardTo('scaleSelector'),
               ],
             },
+            IMAGE_RENDERING_ACTIVE: {
+              actions: forwardTo('scaleSelector'),
+            },
             TOGGLE_IMAGE_INTERPOLATION: {
               actions: [assignInterpolationEnabled, 'toggleInterpolation'],
             },

--- a/src/UI/Layers/createLayersUIMachine.js
+++ b/src/UI/Layers/createLayersUIMachine.js
@@ -99,8 +99,8 @@ const assignImageContext = assign({
       : new ImageActorContext()
     if (labelImage) {
       actorContext.labelImage = labelImage
-      if (!actorContext.renderedScale) {
-        actorContext.renderedScale = labelImage.lowestScale
+      if (!actorContext.targetScale) {
+        actorContext.targetScale = labelImage.lowestScale
       }
     } else {
       image = context.layers.lastAddedData.data
@@ -119,8 +119,8 @@ const assignImageContext = assign({
       return images
     }
 
-    if (!actorContext.renderedScale) {
-      actorContext.renderedScale = image.lowestScale
+    if (!actorContext.targetScale) {
+      actorContext.targetScale = image.lowestScale
     }
 
     actorContext.componentVisibilities = resize(

--- a/src/UI/createUIMachine.js
+++ b/src/UI/createUIMachine.js
@@ -101,6 +101,9 @@ function createUIMachine(options, context) {
             RENDERED_IMAGE_ASSIGNED: {
               actions: forwardTo('images'),
             },
+            IMAGE_RENDERING_ACTIVE: {
+              actions: forwardTo('images'),
+            },
             ADD_LABEL_IMAGE: {
               actions: forwardTo('layers'),
             },

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -28380,7 +28380,7 @@ var scaleSelector = function scaleSelector(context, event) {
         imageActor.send('ADJUST_SCALE_FOR_FRAMERATE')
       } else {
         imageActor.send('SET_IMAGE_SCALE', {
-          renderedScale: parseInt(event.target.value),
+          targetScale: parseInt(event.target.value),
         })
       }
     })

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -28412,10 +28412,7 @@ var scaleSelector = function scaleSelector(context, event) {
         onImageAssigned(event.data)
       } else if (type === 'RENDERED_IMAGE_ASSIGNED') {
         scaleSelector.value = event.loadedScale
-      } else if (
-        type === 'IMAGE_HISTOGRAM_UPDATED' ||
-        type === 'IMAGE_RENDERING_ACTIVE'
-      ) {
+      } else if (type === 'IMAGE_RENDERING_ACTIVE') {
         // set scale number after ADJUST_SCALE_FOR_FRAMERATE even if no scale change
         scaleSelector.value = context.images.actorContext.get(
           event.data.name

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -28343,10 +28343,6 @@ function applyScaleCount(input, scaleCount) {
     })
 }
 
-function applyRenderedScale(input, renderedScale) {
-  input.value = renderedScale
-}
-
 var scaleSelector = function scaleSelector(context, event) {
   return function(send, onReceive) {
     var scaleSelectorDiv = document.createElement('div')
@@ -28409,23 +28405,21 @@ var scaleSelector = function scaleSelector(context, event) {
     }
 
     onImageAssigned(event.data)
-    onReceive(function(_ref) {
-      var type = _ref.type,
-        data = _ref.data
+    onReceive(function(event) {
+      var type = event.type
 
       if (type === 'IMAGE_ASSIGNED') {
-        onImageAssigned(data)
+        onImageAssigned(event.data)
       } else if (type === 'RENDERED_IMAGE_ASSIGNED') {
-        applyRenderedScale(
-          scaleSelector,
-          context.images.actorContext.get(data).renderedScale
-        )
-      } else if (type === 'IMAGE_HISTOGRAM_UPDATED') {
+        scaleSelector.value = event.loadedScale
+      } else if (
+        type === 'IMAGE_HISTOGRAM_UPDATED' ||
+        type === 'IMAGE_RENDERING_ACTIVE'
+      ) {
         // set scale number after ADJUST_SCALE_FOR_FRAMERATE even if no scale change
-        applyRenderedScale(
-          scaleSelector,
-          context.images.actorContext.get(data.name).renderedScale
-        )
+        scaleSelector.value = context.images.actorContext.get(
+          event.data.name
+        ).loadedScale
       }
     })
   }

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -25087,36 +25087,37 @@ const Background = (container, points) => {
       ctx.clip()
       const [headX] = linePoints[1]
       const [tailX] = linePoints[linePoints.length - 2]
-      const headXClamped = Math.max(0, headX)
-      const tailXClamped = Math.min(width, tailX)
-      const colorCanvasWidth =
-        Math.floor(tailXClamped - headXClamped) || borderWidth
-      const pointPixelWidth = tailX - headX
-      const headClampAmount = (headXClamped - headX) / pointPixelWidth
-      const tailClampAmount = (tailXClamped - tailX) / pointPixelWidth
-      const dataRange = colorTransferFunction.getMappingRange()
-      const dataWidth = dataRange[1] - dataRange[0]
-      const visibleDataRange = [
-        dataRange[0] + dataWidth * headClampAmount,
-        dataRange[1] + dataWidth * tailClampAmount,
-      ]
-      updateColorCanvas(
-        colorTransferFunction,
-        colorCanvasWidth,
-        visibleDataRange,
-        colorCanvas
-      )
-      ctx.drawImage(
-        colorCanvas,
-        0,
-        0,
-        colorCanvas.width,
-        colorCanvas.height,
-        Math.floor(headXClamped),
-        Math.floor(top),
-        colorCanvasWidth,
-        Math.ceil(bottom - top)
-      )
+      const headXClamped = Math.min(width, Math.max(0, headX))
+      const tailXClamped = Math.min(width, Math.max(0, tailX))
+      const colorCanvasWidth = Math.ceil(tailXClamped - headXClamped)
+      if (colorCanvasWidth) {
+        const pointPixelWidth = tailX - headX
+        const headClampAmount = (headXClamped - headX) / pointPixelWidth
+        const tailClampAmount = (tailXClamped - tailX) / pointPixelWidth
+        const dataRange = colorTransferFunction.getMappingRange()
+        const dataWidth = dataRange[1] - dataRange[0]
+        const visibleDataRange = [
+          dataRange[0] + dataWidth * headClampAmount,
+          dataRange[1] + dataWidth * tailClampAmount,
+        ]
+        updateColorCanvas(
+          colorTransferFunction,
+          colorCanvasWidth,
+          visibleDataRange,
+          colorCanvas
+        )
+        ctx.drawImage(
+          colorCanvas,
+          0,
+          0,
+          colorCanvas.width,
+          colorCanvas.height,
+          Math.floor(headXClamped),
+          Math.floor(top),
+          colorCanvasWidth,
+          Math.ceil(bottom - top)
+        )
+      }
       ctx.restore()
     }
     if (histogram) {

--- a/src/UI/reference-ui/package-lock.json
+++ b/src/UI/reference-ui/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.17.6",
         "itk-viewer-icons": "^11.12.0",
-        "itk-viewer-transfer-function-editor": "^1.1.3"
+        "itk-viewer-transfer-function-editor": "^1.1.4"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",
@@ -2356,9 +2356,9 @@
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
     "node_modules/itk-viewer-transfer-function-editor": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.3.tgz",
-      "integrity": "sha512-z7j2dNb9IgKz97oDaXd/smB69ttuxLQFQu8FviQRcXasZ/nK1TWqzxGxByPh41RCKdxDPNtL6XYN1KkhYqhu/g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.4.tgz",
+      "integrity": "sha512-1qWJcKdIXbzY9SXrz5ukN3DxkpXB8WTzuRh4HD+kO1WFw2RUJygcxCP3dtQIDiAYXfu0dh1GHZ88SbDdnzxJcg=="
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -6322,9 +6322,9 @@
       "integrity": "sha512-Utd13l7zQbgPmc7OPFdNLAblv/PHx0kN1mSt0bvPnWYWqDFs6BQF2uY5JxtGrJk6tfjgNYb2NT1uHCwYY2YQRQ=="
     },
     "itk-viewer-transfer-function-editor": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.3.tgz",
-      "integrity": "sha512-z7j2dNb9IgKz97oDaXd/smB69ttuxLQFQu8FviQRcXasZ/nK1TWqzxGxByPh41RCKdxDPNtL6XYN1KkhYqhu/g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/itk-viewer-transfer-function-editor/-/itk-viewer-transfer-function-editor-1.1.4.tgz",
+      "integrity": "sha512-1qWJcKdIXbzY9SXrz5ukN3DxkpXB8WTzuRh4HD+kO1WFw2RUJygcxCP3dtQIDiAYXfu0dh1GHZ88SbDdnzxJcg=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/src/UI/reference-ui/package.json
+++ b/src/UI/reference-ui/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.6",
     "itk-viewer-icons": "^11.12.0",
-    "itk-viewer-transfer-function-editor": "^1.1.3"
+    "itk-viewer-transfer-function-editor": "^1.1.4"
   }
 }

--- a/src/UI/reference-ui/src/Images/scaleSelector.js
+++ b/src/UI/reference-ui/src/Images/scaleSelector.js
@@ -54,7 +54,7 @@ const scaleSelector = (context, event) => (send, onReceive) => {
       imageActor.send('ADJUST_SCALE_FOR_FRAMERATE')
     } else {
       imageActor.send('SET_IMAGE_SCALE', {
-        renderedScale: parseInt(event.target.value),
+        targetScale: parseInt(event.target.value),
       })
     }
   })

--- a/src/UI/reference-ui/src/Images/scaleSelector.js
+++ b/src/UI/reference-ui/src/Images/scaleSelector.js
@@ -79,10 +79,7 @@ const scaleSelector = (context, event) => (send, onReceive) => {
       onImageAssigned(event.data)
     } else if (type === 'RENDERED_IMAGE_ASSIGNED') {
       scaleSelector.value = event.loadedScale
-    } else if (
-      type === 'IMAGE_HISTOGRAM_UPDATED' ||
-      type === 'IMAGE_RENDERING_ACTIVE'
-    ) {
+    } else if (type === 'IMAGE_RENDERING_ACTIVE') {
       // set scale number after ADJUST_SCALE_FOR_FRAMERATE even if no scale change
       scaleSelector.value = context.images.actorContext.get(
         event.data.name

--- a/src/UI/reference-ui/src/Images/scaleSelector.js
+++ b/src/UI/reference-ui/src/Images/scaleSelector.js
@@ -16,10 +16,6 @@ function applyScaleCount(input, scaleCount) {
   })
 }
 
-function applyRenderedScale(input, renderedScale) {
-  input.value = renderedScale
-}
-
 const scaleSelector = (context, event) => (send, onReceive) => {
   const scaleSelectorDiv = document.createElement('div')
   scaleSelectorDiv.setAttribute(
@@ -77,20 +73,20 @@ const scaleSelector = (context, event) => (send, onReceive) => {
 
   onImageAssigned(event.data)
 
-  onReceive(({ type, data }) => {
+  onReceive(event => {
+    const { type } = event
     if (type === 'IMAGE_ASSIGNED') {
-      onImageAssigned(data)
+      onImageAssigned(event.data)
     } else if (type === 'RENDERED_IMAGE_ASSIGNED') {
-      applyRenderedScale(
-        scaleSelector,
-        context.images.actorContext.get(data).renderedScale
-      )
-    } else if (type === 'IMAGE_HISTOGRAM_UPDATED') {
+      scaleSelector.value = event.loadedScale
+    } else if (
+      type === 'IMAGE_HISTOGRAM_UPDATED' ||
+      type === 'IMAGE_RENDERING_ACTIVE'
+    ) {
       // set scale number after ADJUST_SCALE_FOR_FRAMERATE even if no scale change
-      applyRenderedScale(
-        scaleSelector,
-        context.images.actorContext.get(data.name).renderedScale
-      )
+      scaleSelector.value = context.images.actorContext.get(
+        event.data.name
+      ).loadedScale
     }
   })
 }

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -1401,10 +1401,10 @@ const createViewer = async (
     store.geometriesUI.opacities[index] = opacity
   }
 
-  publicAPI.setImageScale = renderedScale => {
+  publicAPI.setImageScale = targetScale => {
     service.send({
       type: 'SET_IMAGE_SCALE',
-      renderedScale,
+      targetScale,
     })
   }
 

--- a/src/createViewerMachine.js
+++ b/src/createViewerMachine.js
@@ -171,6 +171,9 @@ const createViewerMachine = (options, context, eventEmitterCallback) => {
                 forwardTo('eventEmitter'),
               ],
             },
+            IMAGE_RENDERING_ACTIVE: {
+              actions: forwardTo('ui'),
+            },
             ADD_LABEL_IMAGE: {
               actions: forwardTo('ui'),
             },


### PR DESCRIPTION
Update scale drop-down to last successfully loaded scale after error loading user selected scale.

Good test case:
http://localhost:8082/?rotate=false&image=https://dandiarchive.s3.amazonaws.com/zarr/3d313fc2-0204-496d-bfa1-5c90951ee640
Then select scale 3 for "Out of memory error transferring to worker" or scale 2 for "to many network requests" error.

closes #544