### PR TITLE
fix(ItkVtkViewProxy): grab crop handles when animating

### DIFF
--- a/src/Rendering/VTKJS/Images/createImageRenderer.js
+++ b/src/Rendering/VTKJS/Images/createImageRenderer.js
@@ -4,7 +4,7 @@ import applyXSlice from '../Main/applyXSlice'
 import applyYSlice from '../Main/applyYSlice'
 import applyZSlice from '../Main/applyZSlice'
 
-import '../vtk/ProportionalOpenGLImageMapper' // calls registerOverride('vtkImageMapper', newInstance)
+import '../vtk/OpenGLImageMapperFractional' // calls registerOverride('vtkImageMapper', newInstance)
 
 async function createImageRenderer(context) {
   if (!context.images.source) {

--- a/src/Rendering/VTKJS/vtk/ItkVtkViewProxy.js
+++ b/src/Rendering/VTKJS/vtk/ItkVtkViewProxy.js
@@ -9,7 +9,8 @@ import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate'
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData'
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox'
 import vtkAxesLabelsWidget from './AxesLabelsWidget'
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager'
+import WidgetManagerPickWhileAnimating from './WidgetManagerPickWhileAnimating'
+
 import vtkSliceOutlineFilter from './SliceOutlineFilter'
 
 const CursorCornerAnnotation =
@@ -668,7 +669,7 @@ function ItkVtkViewProxy(publicAPI, model) {
   model.interactor.onEndPinch(updateScaleBar)
 
   model.widgetManagerInitialized = false
-  model.widgetManager = vtkWidgetManager.newInstance()
+  model.widgetManager = WidgetManagerPickWhileAnimating.newInstance()
   model.widgetsToRegister = []
   model.widgetProps = new Map()
 

--- a/src/Rendering/VTKJS/vtk/OpenGLImageMapperFractional.js
+++ b/src/Rendering/VTKJS/vtk/OpenGLImageMapperFractional.js
@@ -27,9 +27,9 @@ function computeFnToString(property, fn, numberOfComponents) {
   return '0'
 }
 
-function ProportionalOpenGLImageMapper(publicAPI, model) {
+function OpenGLImageMapperFractional(publicAPI, model) {
   // Set our className
-  model.classHierarchy.push('ProportionalOpenGLImageMapper')
+  model.classHierarchy.push('OpenGLImageMapperFractional')
 
   publicAPI.replaceShaderValues = (shaders, ren, actor) => {
     let VSSource = shaders.Vertex
@@ -240,8 +240,6 @@ function ProportionalOpenGLImageMapper(publicAPI, model) {
     publicAPI.replaceShaderClip(shaders, ren, actor)
     publicAPI.replaceShaderCoincidentOffset(shaders, ren, actor)
   }
-
-  // const superBuildBufferObjects = publicAPI.buildBufferObjects
 
   publicAPI.buildBufferObjects = (ren, actor) => {
     const image = model.currentInput
@@ -600,14 +598,14 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   vtkOpenGlImageMapper.extend(publicAPI, model, initialValues)
 
-  ProportionalOpenGLImageMapper(publicAPI, model)
+  OpenGLImageMapperFractional(publicAPI, model)
 }
 
 // ----------------------------------------------------------------------------
 
 export const newInstance = macro.newInstance(
   extend,
-  'ProportionalOpenGLImageMapper'
+  'OpenGLImageMapperFractional'
 )
 
 // ----------------------------------------------------------------------------

--- a/src/Rendering/VTKJS/vtk/WidgetManagerPickWhileAnimating.js
+++ b/src/Rendering/VTKJS/vtk/WidgetManagerPickWhileAnimating.js
@@ -1,0 +1,49 @@
+import Macro from 'vtk.js/Sources/macros'
+import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager'
+
+// Let widgets handleEvents while interactor is animating
+function WidgetManagerPickWhileAnimating(publicAPI, model) {
+  model.classHierarchy.push('WidgetManagerPickWhileAnimating')
+
+  const subscriptions = []
+
+  const superSetRenderer = publicAPI.setRenderer
+  publicAPI.setRenderer = renderer => {
+    superSetRenderer(renderer)
+
+    subscriptions.push(
+      model._interactor.onStartAnimation(() => {
+        model.isAnimating = false // undoes super class setting this to true
+      })
+    )
+  }
+
+  const superDelete = publicAPI.delete
+  publicAPI.delete = () => {
+    while (subscriptions.length) {
+      subscriptions.pop().unsubscribe()
+    }
+    superDelete()
+  }
+}
+
+const DEFAULT_VALUES = {}
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues)
+
+  vtkWidgetManager.extend(publicAPI, model, initialValues)
+
+  WidgetManagerPickWhileAnimating(publicAPI, model)
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = Macro.newInstance(
+  extend,
+  'WidgetManagerPickWhileAnimating'
+)
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend }


### PR DESCRIPTION
Add subclassed WidgetManager to handle events even when interactor is
animating (like with FPS speed checks or auto rotating).

The FPS speed check after each crop handle change triggered the renderWindow.interactor
to be animating which disabled the WidgetManager from handling events.