### PR TITLE
fix(ImageRenderingActor): ignore stale updateRenderedImage results

### DIFF
--- a/src/Rendering/Images/createImagesRenderingMachine.js
+++ b/src/Rendering/Images/createImagesRenderingMachine.js
@@ -71,11 +71,6 @@ function createImagesRenderingMachine(options, context) {
                 to: c => `imageRenderingActor-${c.images.updateRenderedName}`,
               }),
             },
-            RENDERED_IMAGE_ASSIGNED: {
-              actions: send((_, e) => e, {
-                to: (c, e) => `imageRenderingActor-${e.data}`,
-              }),
-            },
             TOGGLE_LAYER_VISIBILITY: {
               actions: send((_, e) => e, {
                 to: c => `imageRenderingActor-${c.images.selectedName}`,

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -19,8 +19,7 @@ const ANNOTATION_CUSTOM_PREFIX =
 const ANNOTATION_CUSTOM_POSTFIX =
   '<td></td><td></td></tr><tr><td style="margin-left: auto; margin-right: 0;">Position:</td><td>${xPosition},</td><td>${yPosition},</td><td>${zPosition}</td></tr><tr><td style="margin-left: auto; margin-right: 0;"">Value:</td><td style="text-align:center;" colspan="3">${value}</td></tr><tr ${annotationLabelStyle}><td style="margin-left: auto; margin-right: 0;">Label:</td><td style="text-align:center;" colspan="3">${annotation}</td></tr></table>'
 
-function applyRenderedImage(context, event) {
-  const name = event.data
+function applyRenderedImage(context, { data: { name } }) {
   const actorContext = context.images.actorContext.get(name)
 
   if (!actorContext.fusedImage) {

--- a/src/Rendering/VTKJS/Images/assignRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/assignRenderedImage.js
@@ -1,0 +1,64 @@
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray'
+import { assign } from 'xstate'
+import numericalSort from '../numericalSort'
+
+const updateContextWithLabelImage = (actorContext, scaleLabelImage) => {
+  const uniqueLabelsSet = new Set(scaleLabelImage.data)
+  const uniqueLabels = Array.from(uniqueLabelsSet)
+  // The volume mapper currently only supports ColorTransferFunction's,
+  // not LookupTable's
+  // lut.setAnnotations(uniqueLabels, uniqueLabels);
+  uniqueLabels.sort(numericalSort)
+  actorContext.uniqueLabels = uniqueLabels
+  actorContext.renderedLabelImage = scaleLabelImage
+}
+
+const assignRenderedImage = assign({
+  images: (
+    { images },
+    { data: { name, componentRanges, itkImage, vtkImage, labelAtScale } }
+  ) => {
+    const actorContext = images.actorContext.get(name)
+
+    if (labelAtScale) updateContextWithLabelImage(actorContext, labelAtScale)
+
+    actorContext.fusedImageRanges = componentRanges
+    actorContext.fusedImageData = itkImage.data
+    const { fusedImageData } = actorContext
+
+    if (!actorContext.fusedImage) {
+      actorContext.fusedImage = vtkImage
+    } else {
+      // re-use fusedImage
+      actorContext.fusedImage.setOrigin(vtkImage.getOrigin())
+      actorContext.fusedImage.setSpacing(vtkImage.getSpacing())
+      actorContext.fusedImage.setDirection(vtkImage.getDirection())
+      actorContext.fusedImage.setDimensions(vtkImage.getDimensions())
+    }
+    const { fusedImage } = actorContext
+
+    const imageScalars = vtkImage.getPointData().getScalars()
+
+    const numberOfComponents = itkImage.imageType.components
+    const fusedImageScalars = vtkDataArray.newInstance({
+      name: imageScalars.getName() || 'Scalars',
+      values: fusedImageData,
+      numberOfComponents,
+    })
+
+    // for areBoundsBigger guard
+    actorContext.loadedBounds = actorContext.fusedImage.getBounds()
+
+    fusedImage.getPointData().setScalars(fusedImageScalars)
+    // Trigger VolumeMapper scalarTexture update
+    fusedImage.modified()
+
+    componentRanges.forEach((range, comp) =>
+      fusedImageScalars.setRange(range, comp)
+    )
+
+    return images
+  },
+})
+
+export default assignRenderedImage

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -8,6 +8,7 @@ import toggleInterpolation from './toggleInterpolation'
 import applyColorRange from './applyColorRange'
 import applyColorMap from './applyColorMap'
 import applyRenderedImage from './applyRenderedImage'
+import assignRenderedImage from './assignRenderedImage'
 import applyPiecewiseFunction from './applyPiecewiseFunction'
 import applyShadow from './applyShadow'
 import applyGradientOpacity from './applyGradientOpacity'
@@ -66,6 +67,7 @@ const imagesRenderingMachineOptions = {
 
     actions: {
       applyRenderedImage,
+      assignRenderedImage,
 
       toggleLayerVisibility,
 

--- a/src/Rendering/createRenderingMachine.js
+++ b/src/Rendering/createRenderingMachine.js
@@ -141,9 +141,6 @@ const createRenderingMachine = (options, context) => {
             UPDATE_RENDERED_IMAGE: {
               actions: forwardTo('images'),
             },
-            RENDERED_IMAGE_ASSIGNED: {
-              actions: forwardTo('images'),
-            },
             TOGGLE_IMAGE_INTERPOLATION: {
               actions: forwardTo('images'),
             },

--- a/src/createViewerMachine.js
+++ b/src/createViewerMachine.js
@@ -165,11 +165,7 @@ const createViewerMachine = (options, context, eventEmitterCallback) => {
               actions: [forwardTo('rendering')],
             },
             RENDERED_IMAGE_ASSIGNED: {
-              actions: [
-                forwardTo('ui'),
-                forwardTo('rendering'),
-                forwardTo('eventEmitter'),
-              ],
+              actions: [forwardTo('ui'), forwardTo('eventEmitter')],
             },
             IMAGE_RENDERING_ACTIVE: {
               actions: forwardTo('ui'),


### PR DESCRIPTION
User set bounds and scale could get out of sync with rendering.  Steps:
1. Trigger slow updateRenderedImage by setting super fine scale.
2. Trigger fast updateRenderedImage by setting coarse or cached scale.
3. Fast updateRenderedImage sets rendering, then stale slow updateRenderedImage
overrides the more up to date updateRenderedImage result.

Update context and the rendering after updateRenderedImage Promise
resolves.  Promise result is ignored if loadingImage
state has been exited.