### PR TITLE
Load image bounded by camera frustum

### DIFF
--- a/src/Context/ImageActorContext.js
+++ b/src/Context/ImageActorContext.js
@@ -45,10 +45,14 @@ class ImageActorContext {
   // Map of image intensity component to array of [minValue, maxValue] for
   // mapping colors
   colorRanges = new Map()
+  // If not touched, keep growing ranges as new parts of the image are loaded
+  colorRangesTouched = new Map()
 
   // Map of image intensity component to array of [minBound, maxBound] for
   // limiting the color range in the UI
   colorRangeBounds = new Map()
+  // If not touched, keep growing bounds as new parts of the image are loaded
+  colorRangeBoundsTouched = new Map()
 
   // Map of the image intensity component to an object representing the
   // piecewise function. This object has two properties: range and nodes.

--- a/src/Context/ImageActorContext.js
+++ b/src/Context/ImageActorContext.js
@@ -2,9 +2,6 @@ class ImageActorContext {
   // MultiscaleSpatialImage to be visualized
   image = null
 
-  // The target image scale
-  targetScale = null
-
   // The successfully loaded scale
   loadedScale = null
 
@@ -45,14 +42,16 @@ class ImageActorContext {
   // Map of image intensity component to array of [minValue, maxValue] for
   // mapping colors
   colorRanges = new Map()
-  // If not touched, keep growing ranges as new parts of the image are loaded
-  colorRangesTouched = new Map()
+  // Keep growing component ranges as new parts of the image are loaded
+  // Map of image intensity component to Boolean
+  colorRangesAutoAdjust = null
 
   // Map of image intensity component to array of [minBound, maxBound] for
   // limiting the color range in the UI
   colorRangeBounds = new Map()
-  // If not touched, keep growing bounds as new parts of the image are loaded
-  colorRangeBoundsTouched = new Map()
+  // Keep growing component bounds as new parts of the image are loaded
+  // Map of image intensity component to Boolean
+  colorRangeBoundsAutoAdjust = null
 
   // Map of the image intensity component to an object representing the
   // piecewise function. This object has two properties: range and nodes.

--- a/src/Context/MainMachineContext.js
+++ b/src/Context/MainMachineContext.js
@@ -52,15 +52,16 @@ class MainMachineContext {
 
   // Cropping planes widget enabled
   croppingPlanesEnabled = false
+  areCroppingPlanesTouched = false
 
-  // Cropping planes. These typically define square or a cube of a region of
+  // Cropping planes. These typically define a box containing a region of
   // interest in space. The visualization is cropped outside of these planes.
   // Each is characterized with: { origin, normal }.
   //
   // origin: x,y,z point at a point in the plane
   // normal: 3-component vector defining the normal to the plane
   //
-  // An array of six planes that are ordered, when the planes are axis aligned:
+  // An example: An array of six planes. When the planes are axis aligned:
   // -x, +x, -y, +y, -z, +z
   croppingPlanes = null
 

--- a/src/IO/ConglomerateMultiscaleSpatialImage.js
+++ b/src/IO/ConglomerateMultiscaleSpatialImage.js
@@ -21,11 +21,18 @@ export class ConglomerateMultiscaleSpatialImage extends MultiscaleSpatialImage {
     this.images = images
   }
 
-  async buildImage(scale, bounds) {
-    // Run sequentially rather than Promise.all to avoid hang
+  async getImage(scale, worldBounds = []) {
+    this.worldBoundsStashedForOurBuildImage = worldBounds
+    return super.getImage(scale, worldBounds)
+  }
+
+  async buildImage(scale /*bounds*/) {
+    // Run sequentially rather than Promise.all to avoid hang during chunk fetching
     const builtImages = []
     for (const image of this.images) {
-      builtImages.push(await image.buildImage(scale, bounds))
+      builtImages.push(
+        await image.getImage(scale, this.worldBoundsStashedForOurBuildImage)
+      )
     }
     return builtImages
   }

--- a/src/IO/ConglomerateMultiscaleSpatialImage.js
+++ b/src/IO/ConglomerateMultiscaleSpatialImage.js
@@ -22,7 +22,7 @@ export class ConglomerateMultiscaleSpatialImage extends MultiscaleSpatialImage {
   }
 
   async getImage(scale, worldBounds = []) {
-    this.worldBoundsStashedForOurBuildImage = worldBounds
+    this.worldBoundsForBuildImage = worldBounds
     return super.getImage(scale, worldBounds)
   }
 
@@ -31,7 +31,7 @@ export class ConglomerateMultiscaleSpatialImage extends MultiscaleSpatialImage {
     const builtImages = []
     for (const image of this.images) {
       builtImages.push(
-        await image.getImage(scale, this.worldBoundsStashedForOurBuildImage)
+        await image.getImage(scale, this.worldBoundsForBuildImage)
       )
     }
     return builtImages

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -6,15 +6,16 @@ const getLoadedImage = actorContext =>
 const assignColorRange = assign({
   images: (
     { images },
-    { data: { name, component, range, fromAutomation = false } }
+    { data: { name, component, range, keepAutoAdjusting = false } }
   ) => {
-    const { colorRanges, colorRangesTouched } = images.actorContext.get(name)
+    const { colorRanges, colorRangesAutoAdjust } = images.actorContext.get(name)
 
     colorRanges.set(component, range)
 
-    if (!fromAutomation) {
-      colorRangesTouched.set(component, true)
-    }
+    colorRangesAutoAdjust.set(
+      component,
+      colorRangesAutoAdjust.get(component) && keepAutoAdjusting
+    )
 
     return images
   },

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -220,10 +220,10 @@ const eventResponses = {
   // updateRenderedImage->applyRenderedImage->updateCroppingParametersFromImage->CROPPING_PLANES_CHANGED
   // because image size may change across scales.
   CROPPING_PLANES_CHANGED_BY_USER: {
-    target: 'debouncingUpdatingImage',
+    target: 'debouncedImageUpdate',
   },
   CAMERA_MODIFIED: {
-    target: 'debouncingUpdatingImage',
+    target: 'debouncedImageUpdate',
   },
 }
 
@@ -326,7 +326,7 @@ const createImageRenderingActor = (options, context /*, event*/) => {
           },
         },
 
-        debouncingUpdatingImage: {
+        debouncedImageUpdate: {
           on: {
             ...eventResponses,
           },

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -62,6 +62,15 @@ const assignLoadedScale = assign({
   },
 })
 
+const assignClearHistograms = assign({
+  images: ({ images }, { data }) => {
+    const name = data.name ?? data
+    const actorContext = images.actorContext.get(name)
+    actorContext.histograms = new Map()
+    return images
+  },
+})
+
 const LOW_FPS = 10.0
 const JUST_ACCEPTABLE_FPS = 30.0
 
@@ -230,6 +239,7 @@ const createUpdatingImageMachine = options => {
               actions: [
                 'assignRenderedImage',
                 assignLoadedScale,
+                assignClearHistograms,
                 'applyRenderedImage',
                 sendRenderedImageAssigned,
               ],

--- a/src/Rendering/Images/createImagesRenderingMachine.js
+++ b/src/Rendering/Images/createImagesRenderingMachine.js
@@ -96,6 +96,11 @@ function createImagesRenderingMachine(options, context) {
                 to: (c, e) => `imageRenderingActor-${e.data.name}`,
               }),
             },
+            IMAGE_COLOR_RANGE_BOUNDS_CHANGED: {
+              actions: send((_, e) => e, {
+                to: (c, e) => `imageRenderingActor-${e.data.name}`,
+              }),
+            },
             IMAGE_COLOR_RANGE_CHANGED: {
               actions: send((_, e) => e, {
                 to: (c, e) => `imageRenderingActor-${e.data.name}`,

--- a/src/Rendering/Images/createImagesRenderingMachine.js
+++ b/src/Rendering/Images/createImagesRenderingMachine.js
@@ -24,10 +24,10 @@ function spawnImageRenderingActor(options) {
   })
 }
 
-const sendEventToAllActors = eventType =>
-  actions.pure(({ images: { imageRenderingActors } }) =>
+const sendEventToAllActors = () =>
+  actions.pure(({ images: { imageRenderingActors } }, event) =>
     Array.from(imageRenderingActors.values()).map(actor =>
-      send(eventType, {
+      send(event, {
         to: actor,
       })
     )
@@ -184,10 +184,10 @@ function createImagesRenderingMachine(options, context) {
               }),
             },
             CROPPING_PLANES_CHANGED_BY_USER: {
-              actions: sendEventToAllActors('CROPPING_PLANES_CHANGED_BY_USER'),
+              actions: sendEventToAllActors(),
             },
             CAMERA_MODIFIED: {
-              actions: sendEventToAllActors('CAMERA_MODIFIED'),
+              actions: sendEventToAllActors(),
             },
           },
         },

--- a/src/Rendering/VTKJS/Images/applyColorRangeBounds.js
+++ b/src/Rendering/VTKJS/Images/applyColorRangeBounds.js
@@ -1,16 +1,18 @@
 const assignColorRangeBounds = (
   { images },
-  { data: { name, component, range, fromAutomation = false } }
+  { data: { name, component, range, keepAutoAdjusting = false } }
 ) => {
-  const { colorRangeBounds, colorRangeBoundsTouched } = images.actorContext.get(
-    name
-  )
+  const {
+    colorRangeBounds,
+    colorRangeBoundsAutoAdjust,
+  } = images.actorContext.get(name)
 
   colorRangeBounds.set(component, range)
 
-  if (!fromAutomation) {
-    colorRangeBoundsTouched.set(component, true)
-  }
+  colorRangeBoundsAutoAdjust.set(
+    component,
+    colorRangeBoundsAutoAdjust.get(component) && keepAutoAdjusting
+  )
 
   return images
 }

--- a/src/Rendering/VTKJS/Images/applyColorRangeBounds.js
+++ b/src/Rendering/VTKJS/Images/applyColorRangeBounds.js
@@ -1,0 +1,52 @@
+const assignColorRangeBounds = (
+  { images },
+  { data: { name, component, range, fromAutomation = false } }
+) => {
+  const { colorRangeBounds, colorRangeBoundsTouched } = images.actorContext.get(
+    name
+  )
+
+  colorRangeBounds.set(component, range)
+
+  if (!fromAutomation) {
+    colorRangeBoundsTouched.set(component, true)
+  }
+
+  return images
+}
+
+export const applyColorRangeBounds = (context, event) => {
+  const {
+    data: { name, component, range: newRange },
+  } = event
+  const { colorRangeBounds } = context.images.actorContext.get(name)
+  const oldBounds = colorRangeBounds.get(component)
+
+  assignColorRangeBounds(context, event)
+
+  if (!oldBounds) return
+
+  // Rescale opacity points to fit range
+
+  const oldRangeDiff = oldBounds[1] - oldBounds[0]
+  const newRangeDiff = newRange[1] - newRange[0]
+
+  const actorContext = context.images.actorContext.get(name)
+  const oldPoints = actorContext.piecewiseFunctionPoints?.get(component)
+  const points = oldPoints
+    // find real intensity value of normalized points
+    .map(([x, y]) => [x * oldRangeDiff + oldBounds[0], y])
+    // rescale to new range
+    .map(([x, y]) => {
+      return [(x - newRange[0]) / newRangeDiff, y]
+    })
+
+  context.service.send({
+    type: 'IMAGE_PIECEWISE_FUNCTION_POINTS_CHANGED',
+    data: {
+      name,
+      component,
+      points,
+    },
+  })
+}

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -281,7 +281,7 @@ function applyRenderedImage(context, { data: { name } }) {
     data: { name, volumeSampleDistance: actorContext.volumeSampleDistance },
   })
 
-  representationProxy.getMapper().setMaximumSamplesPerRay(2048)
+  representationProxy.getMapper().setMaximumSamplesPerRay(2814)
 
   // update color ranges
   actorContext.visualizedComponents

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -6,7 +6,6 @@ import applyGradientOpacity from './applyGradientOpacity'
 import applyLabelImageBlend from './applyLabelImageBlend'
 import applyVolumeSampleDistance from './applyVolumeSampleDistance'
 import {
-  addCroppingPlanes,
   makeCroppable,
   updateCroppingParametersFromImage,
 } from '../Main/croppingPlanes'
@@ -18,6 +17,47 @@ const ANNOTATION_CUSTOM_PREFIX =
   '<table style="margin-left: 0;"><tr><td style="margin-left: auto; margin-right: 0;">Scale:</td>'
 const ANNOTATION_CUSTOM_POSTFIX =
   '<td></td><td></td></tr><tr><td style="margin-left: auto; margin-right: 0;">Position:</td><td>${xPosition},</td><td>${yPosition},</td><td>${zPosition}</td></tr><tr><td style="margin-left: auto; margin-right: 0;"">Value:</td><td style="text-align:center;" colspan="3">${value}</td></tr><tr ${annotationLabelStyle}><td style="margin-left: auto; margin-right: 0;">Label:</td><td style="text-align:center;" colspan="3">${annotation}</td></tr></table>'
+
+const getDefaultRangeByDataType = dataType => {
+  const range = []
+  switch (dataType) {
+    case 'Uint8Array':
+      range[0] = 0
+      range[1] = 255
+      break
+    case 'Int8Array':
+      range[0] = -128
+      range[1] = 127
+      break
+    case 'Uint16Array':
+      range[0] = 0
+      range[1] = 65535
+      break
+    case 'Int16Array':
+      range[0] = -32768
+      range[1] = 32767
+      break
+    case 'Uint32Array':
+      range[0] = 0
+      range[1] = 4294967295
+      break
+    case 'Int32Array':
+      range[0] = -2147483648
+      range[1] = 2147483647
+      break
+    case 'BigInt64Array':
+      range[0] = BigInt(-9223372036854775808)
+      range[1] = BigInt(9223372036854775808)
+      break
+    case 'Float32Array':
+      range[0] = 0.0
+      range[1] = 1.0
+      break
+    default:
+      console.error('Unsupported data type')
+  }
+  return range
+}
 
 function applyRenderedImage(context, { data: { name } }) {
   const actorContext = context.images.actorContext.get(name)
@@ -33,13 +73,11 @@ function applyRenderedImage(context, { data: { name } }) {
 
   context.images.source.setInputData(actorContext.fusedImage)
 
-  const volumeProxy = context.images.representationProxy
   const savedSlicePositions = context.images.representationProxy && [
-    volumeProxy.getXSlice(),
-    volumeProxy.getYSlice(),
-    volumeProxy.getZSlice(),
+    context.images.representationProxy.getXSlice(),
+    context.images.representationProxy.getYSlice(),
+    context.images.representationProxy.getZSlice(),
   ]
-
   // VTK.js currently only supports a single image
   if (!context.images.representationProxy) {
     context.proxyManager.createRepresentationInAllViews(context.images.source)
@@ -49,7 +87,7 @@ function applyRenderedImage(context, { data: { name } }) {
     )
     const { representationProxy } = context.images
 
-    makeCroppable(representationProxy)
+    makeCroppable(context, representationProxy)
 
     if (context.use2D) {
       context.itkVtkView.setViewMode('ZPlane')
@@ -58,17 +96,12 @@ function applyRenderedImage(context, { data: { name } }) {
       context.itkVtkView.setViewMode('Volume')
     }
 
-    representationProxy.getMapper().setMaximumSamplesPerRay(2048)
-    representationProxy.setSampleDistance(actorContext.volumeSampleDistance)
-
     context.itkVtkView.setAxesNames(image?.scaleInfo[0].axesNames) // ? for no image, only imageLabel case
 
     const annotationContainer = context.renderingViewContainers
       .get('volume')
       .querySelector('.js-se')
     annotationContainer.style.fontFamily = 'monospace'
-
-    addCroppingPlanes(context, representationProxy)
 
     const { widgetCroppingPlanes } = context.main
     const sliceActors = representationProxy.getActors()
@@ -100,14 +133,18 @@ function applyRenderedImage(context, { data: { name } }) {
   } else {
     context.images.representationProxy.setInput(context.images.source)
   }
+  const { representationProxy } = context.images
+
+  // undo representationProxy.setInput calling volume.setVisibility(false) if it finds dimensions === 2 (may have just been cropped)
+  representationProxy.setVolumeVisibility(!context.use2D)
 
   // triggers update of ImageSliceOutlines if fusedImage size changed
-  context.images.representationProxy
-    .getActors()
-    .forEach(actor => actor.getMapper().modified())
+  representationProxy.getActors().forEach(actor => actor.getMapper().modified())
 
   // call after representations are created
   updateCroppingParametersFromImage(context, actorContext.fusedImage)
+
+  context.itkVtkView.getRenderer().resetCameraClippingRange()
 
   // Create color map and piecewise function objects as needed
   if (typeof context.images.lookupTableProxies === 'undefined') {
@@ -244,86 +281,78 @@ function applyRenderedImage(context, { data: { name } }) {
     data: { name, volumeSampleDistance: actorContext.volumeSampleDistance },
   })
 
-  // Set default color ranges
-  actorContext.visualizedComponents.forEach(
-    (componentIndex, fusedImageIndex) => {
-      if (
-        !actorContext.colorRanges.has(componentIndex) ||
-        !actorContext.colorRangeBounds.has(componentIndex)
-      ) {
-        if (componentIndex < 0) {
-          return
-        }
-        const dataArray = actorContext.fusedImage.getPointData().getScalars()
-        const range = dataArray.getRange(fusedImageIndex).slice()
-        if (!actorContext.independentComponents || range[1] === range[0]) {
-          switch (dataArray.getDataType()) {
-            case 'Uint8Array':
-              range[0] = 0
-              range[1] = 255
-              break
-            case 'Int8Array':
-              range[0] = -128
-              range[1] = 127
-              break
-            case 'Uint16Array':
-              range[0] = 0
-              range[1] = 65535
-              break
-            case 'Int16Array':
-              range[0] = -32768
-              range[1] = 32767
-              break
-            case 'Uint32Array':
-              range[0] = 0
-              range[1] = 4294967295
-              break
-            case 'Int32Array':
-              range[0] = -2147483648
-              range[1] = 2147483647
-              break
-            case 'BigUint64Array':
-              range[0] = 0
-              range[1] = BigInt(18446744073709551615)
-              break
-            case 'BigInt64Array':
-              range[0] = BigInt(-9223372036854775808)
-              range[1] = BigInt(9223372036854775808)
-              break
-            case 'Float32Array':
-              range[0] = 0.0
-              range[1] = 1.0
-              break
-            case 'Float64Array':
-              range[0] = 0.0
-              range[1] = 1.0
-              break
-            default:
-              console.error('Unsupported data type')
-          }
-        }
-        if (!actorContext.colorRangeBounds.has(componentIndex)) {
+  representationProxy.getMapper().setMaximumSamplesPerRay(2048)
+
+  // update color ranges
+  actorContext.visualizedComponents
+    .map((componentIndex, fusedImageIndex) => [componentIndex, fusedImageIndex])
+    .filter(([componentIndex]) => componentIndex >= 0) // skip label map
+    .forEach(([componentIndex, fusedImageIndex]) => {
+      const {
+        colorRangeBoundsTouched,
+        colorRangeBounds,
+        colorRanges,
+        colorRangesTouched,
+      } = actorContext
+
+      const dataArray = actorContext.fusedImage.getPointData().getScalars()
+      const [dataMin, dataMax] = dataArray.getRange(fusedImageIndex)
+
+      const [newMin, newMax] =
+        !actorContext.independentComponents || dataMin - dataMax === 0
+          ? getDefaultRangeByDataType(dataArray.getDataType())
+          : [dataMin, dataMax]
+
+      if (!colorRangeBoundsTouched.get(componentIndex)) {
+        const oldRange = colorRangeBounds.get(componentIndex) ?? [
+          Number.POSITIVE_INFINITY,
+          Number.NEGATIVE_INFINITY,
+        ]
+        // only grow range
+        const newRange = [
+          Math.min(newMin, oldRange[0]),
+          Math.max(newMax, oldRange[1]),
+        ]
+        const hasChanged = newRange.some((value, i) => value !== oldRange[i])
+        if (hasChanged) {
           context.service.send({
             type: 'IMAGE_COLOR_RANGE_BOUNDS_CHANGED',
-            data: { name, component: componentIndex, range },
+            data: {
+              name,
+              component: componentIndex,
+              range: newRange,
+              fromAutomation: true,
+            },
           })
         }
-        if (!actorContext.colorRanges.has(componentIndex)) {
+      }
+
+      const storedColorRange = colorRanges.get(componentIndex)
+      const oldRange = storedColorRange ?? [
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ]
+      if (!colorRangesTouched.get(componentIndex) || !storedColorRange) {
+        // only grow range
+        const newRange = [
+          Math.min(newMin, oldRange[0]),
+          Math.max(newMax, oldRange[1]),
+        ]
+        const hasChanged = newRange.some((value, i) => value !== oldRange[i])
+
+        if (hasChanged) {
           context.service.send({
             type: 'IMAGE_COLOR_RANGE_CHANGED',
-            data: { name, component: componentIndex, range },
+            data: {
+              name,
+              component: componentIndex,
+              range: newRange,
+              fromAutomation: true,
+            },
           })
         }
-      } else {
-        // Always send IMAGE_COLOR_RANGE_CHANGED to trigger IMAGE_PIECEWISE_FUNCTION_CHANGED
-        const range = actorContext.colorRanges.get(componentIndex)
-        context.service.send({
-          type: 'IMAGE_COLOR_RANGE_CHANGED',
-          data: { name, component: componentIndex, range },
-        })
       }
-    }
-  )
+    })
 
   if (labelImage) {
     const uniqueLabels = actorContext.uniqueLabels

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -289,10 +289,10 @@ function applyRenderedImage(context, { data: { name } }) {
     .filter(([componentIndex]) => componentIndex >= 0) // skip label map
     .forEach(([componentIndex, fusedImageIndex]) => {
       const {
-        colorRangeBoundsTouched,
+        colorRangeBoundsAutoAdjust,
         colorRangeBounds,
         colorRanges,
-        colorRangesTouched,
+        colorRangesAutoAdjust,
       } = actorContext
 
       const dataArray = actorContext.fusedImage.getPointData().getScalars()
@@ -303,7 +303,7 @@ function applyRenderedImage(context, { data: { name } }) {
           ? getDefaultRangeByDataType(dataArray.getDataType())
           : [dataMin, dataMax]
 
-      if (!colorRangeBoundsTouched.get(componentIndex)) {
+      if (colorRangeBoundsAutoAdjust.get(componentIndex)) {
         const oldRange = colorRangeBounds.get(componentIndex) ?? [
           Number.POSITIVE_INFINITY,
           Number.NEGATIVE_INFINITY,
@@ -321,7 +321,7 @@ function applyRenderedImage(context, { data: { name } }) {
               name,
               component: componentIndex,
               range: newRange,
-              fromAutomation: true,
+              keepAutoAdjusting: true,
             },
           })
         }
@@ -332,7 +332,7 @@ function applyRenderedImage(context, { data: { name } }) {
         Number.POSITIVE_INFINITY,
         Number.NEGATIVE_INFINITY,
       ]
-      if (!colorRangesTouched.get(componentIndex) || !storedColorRange) {
+      if (colorRangesAutoAdjust.get(componentIndex) || !storedColorRange) {
         // only grow range
         const newRange = [
           Math.min(newMin, oldRange[0]),
@@ -347,7 +347,7 @@ function applyRenderedImage(context, { data: { name } }) {
               name,
               component: componentIndex,
               range: newRange,
-              fromAutomation: true,
+              keepAutoAdjusting: true,
             },
           })
         }

--- a/src/Rendering/VTKJS/Images/applyVolumeSampleDistance.js
+++ b/src/Rendering/VTKJS/Images/applyVolumeSampleDistance.js
@@ -1,8 +1,6 @@
 function applyVolumeSampleDistance(context, event) {
-  const name = event.data.name
-  const volumeSampleDistance = event.data.volumeSampleDistance
-
-  if (!!context.images.representationProxy) {
+  if (context.images.representationProxy) {
+    const { volumeSampleDistance } = event.data
     context.images.representationProxy.setSampleDistance(volumeSampleDistance)
     const sourceDS = context.images.representationProxy.getInputDataSet()
     const sampleDistance =

--- a/src/Rendering/VTKJS/Images/fuseImages.js
+++ b/src/Rendering/VTKJS/Images/fuseImages.js
@@ -29,7 +29,7 @@ export const fuseImages = async ({
           compInfos.push(compInfo)
         } else {
           console.error(
-            `Size not equal while fusing images! Last image size: ${baseSize}, "${compInfo.image.name}" image size: ${compInfo.image.size}`
+            `Size not equal while fusing images! First image size: ${baseSize}, this image size: ${compInfo.image.size}`
           )
         }
         return [baseSize, compInfos]

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -6,6 +6,7 @@ import updateHistogram from './updateHistogram'
 import selectImageLayer from './selectImageLayer'
 import toggleInterpolation from './toggleInterpolation'
 import applyColorRange from './applyColorRange'
+import { applyColorRangeBounds } from './applyColorRangeBounds'
 import applyColorMap from './applyColorMap'
 import applyRenderedImage from './applyRenderedImage'
 import assignRenderedImage from './assignRenderedImage'
@@ -74,6 +75,7 @@ const imagesRenderingMachineOptions = {
 
       applyPiecewiseFunction,
       applyColorRange,
+      applyColorRangeBounds,
       applyColorMap,
       mapToPiecewiseFunctionNodes,
 

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -97,7 +97,6 @@ const imagesRenderingMachineOptions = {
         images.actorContext.get(images.updateRenderedName)
           .isFramerateScalePickingOn,
 
-      // Check if different scale than loaded or if bounds are larger than loaded
       isImageUpdateNeeded: context =>
         context.isUpdateForced ||
         !isTargetScaleLoaded(context) ||

--- a/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/Images/imagesRenderingMachineOptions.js
@@ -20,10 +20,8 @@ import applyLabelNames from './applyLabelNames'
 import applyLabelImageWeights from './applyLabelImageWeights'
 import applySelectedLabel from './applySelectedLabel'
 import mapToPiecewiseFunctionNodes from './mapToPiecewiseFunctionNodes'
-import {
-  computeRenderedBounds,
-  getBoundsOfFullImage,
-} from '../Main/croppingPlanes'
+import { getBoundsOfFullImage } from '../Main/croppingPlanes'
+import { computeRenderedBounds } from '../Main/computeRenderedBounds'
 
 const EPSILON = 0.000001
 

--- a/src/Rendering/VTKJS/Images/mapToPiecewiseFunctionNodes.js
+++ b/src/Rendering/VTKJS/Images/mapToPiecewiseFunctionNodes.js
@@ -22,6 +22,8 @@ function mapToPiecewiseFunctionNodes(
   const actorContext = context.images.actorContext.get(name)
   const dataRange = actorContext.colorRangeBounds.get(component)
 
+  if (!dataRange) return // viewer.setImagePiecewiseFunctionPoints called at start
+
   const nodes = getNodes(dataRange, points)
   const range = getRange(nodes) ?? dataRange
 

--- a/src/Rendering/VTKJS/Images/updateHistogram.js
+++ b/src/Rendering/VTKJS/Images/updateHistogram.js
@@ -31,7 +31,7 @@ async function updateHistogram(context, event) {
   const fusedImageComponent = actorContext.visualizedComponents.indexOf(
     component
   )
-  const [min, max] = actorContext.colorRanges.get(component) ?? [0, 0] // [0, 0] default for no image, only imageLabel case
+  const [min, max] = actorContext.colorRangeBounds.get(component) ?? [0, 0] // [0, 0] default for no image, only imageLabel case
 
   let numberOfBins = 256
   if (

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -3,7 +3,7 @@ import vtkITKHelper from 'vtk.js/Sources/Common/DataModel/ITKHelper'
 import updateVisualizedComponents from './updateVisualizedComponents'
 import { fuseImages } from './fuseImages'
 import { computeRanges } from './fuseImagesUtils'
-import { computeRenderedBounds } from '../Main/croppingPlanes'
+import { computeRenderedBounds } from '../Main/computeRenderedBounds'
 import { worldBoundsToIndexBounds } from '../../../IO/MultiscaleSpatialImage'
 import { mat4 } from 'gl-matrix'
 
@@ -48,9 +48,10 @@ async function updateRenderedImage(context) {
 
   const { targetScale } = context
 
-  const boundsToLoad = context.main.areCroppingPlanesTouched
-    ? computeRenderedBounds(context)
-    : undefined // if not touched, keep growing bounds to fit whole image
+  // const boundsToLoad = context.main.areCroppingPlanesTouched
+  //   ? computeRenderedBounds(context)
+  //   : undefined // if not touched, keep growing bounds to fit whole image
+  const boundsToLoad = computeRenderedBounds(context)
 
   const voxelCount = await getVoxelCount(
     image || labelImage,

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -7,7 +7,7 @@ import { computeRenderedBounds } from '../Main/computeRenderedBounds'
 import { worldBoundsToIndexBounds } from '../../../IO/MultiscaleSpatialImage'
 import { mat4 } from 'gl-matrix'
 
-export const RENDERED_VOXEL_MAX = 512 * 512 * 512
+export const RENDERED_VOXEL_MAX = 512 * 512 * 512 * 2
 
 const getVoxelCount = async (image, bounds, scale) => {
   const scaleInfo = image.scaleInfo[scale]

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -48,10 +48,11 @@ async function updateRenderedImage(context) {
 
   const { targetScale } = context
 
-  // const boundsToLoad = context.main.areCroppingPlanesTouched
-  //   ? computeRenderedBounds(context)
-  //   : undefined // if not touched, keep growing bounds to fit whole image
-  const boundsToLoad = computeRenderedBounds(context)
+  // always load full image if least detailed scale
+  const isCoarsestScale = (image || labelImage).coarsestScale === targetScale
+  const boundsToLoad = isCoarsestScale
+    ? undefined
+    : computeRenderedBounds(context)
 
   const voxelCount = await getVoxelCount(
     image || labelImage,

--- a/src/Rendering/VTKJS/Main/computeRenderedBounds.js
+++ b/src/Rendering/VTKJS/Main/computeRenderedBounds.js
@@ -1,0 +1,54 @@
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox'
+
+const NDC_RANGE = [0, 1]
+
+// unproject NDC box
+const computeFrustumBoundingBox = renderer => {
+  const view = renderer.getRenderWindow().getViews()[0]
+
+  const dims = view.getViewportSize(renderer)
+  const aspect = dims[0] / dims[1]
+
+  const frustumBounds = [...vtkBoundingBox.INIT_BOUNDS]
+  for (const x of NDC_RANGE) {
+    for (const y of NDC_RANGE) {
+      for (const z of NDC_RANGE) {
+        const corner = renderer.normalizedDisplayToWorld(x, y, z, aspect)
+        vtkBoundingBox.addPoint(frustumBounds, ...corner)
+      }
+    }
+  }
+  return frustumBounds
+}
+
+const computeCroppingPlanesBoundingBox = croppingPlanes => {
+  const planeBounds = [...vtkBoundingBox.INIT_BOUNDS]
+  croppingPlanes.forEach(({ origin }) =>
+    vtkBoundingBox.addPoint(planeBounds, ...origin)
+  )
+  return planeBounds
+}
+
+const intersectBoxes = (b1, b2) =>
+  b1.map(
+    (bound, i) =>
+      i % 2
+        ? Math.min(bound, b2[i]) // high bound case
+        : Math.max(bound, b2[i]) // low bound case
+  )
+
+export const computeRenderedBounds = ({
+  main: { croppingPlanes, areCroppingPlanesTouched },
+  itkVtkView,
+}) => {
+  const frustumBox = computeFrustumBoundingBox(itkVtkView.getRenderer())
+
+  const areCroppingPlanesRelevant =
+    croppingPlanes && croppingPlanes.length === 6 && areCroppingPlanesTouched
+  return areCroppingPlanesRelevant
+    ? intersectBoxes(
+        computeCroppingPlanesBoundingBox(croppingPlanes),
+        frustumBox
+      )
+    : frustumBox
+}

--- a/src/Rendering/VTKJS/Main/croppingPlanes.js
+++ b/src/Rendering/VTKJS/Main/croppingPlanes.js
@@ -29,24 +29,12 @@ export function getBoundsOfFullImage({ images }) {
   return multiScale.getWorldBounds(imageActorContext.loadedScale)
 }
 
-export function computeRenderedBounds(context) {
-  if (!context.main.croppingPlanes || context.main.croppingPlanes.length !== 6)
-    return
-
-  const renderedBounds = [...vtkBoundingBox.INIT_BOUNDS]
-  context.main.croppingPlanes.forEach(({ origin }) =>
-    vtkBoundingBox.addPoint(renderedBounds, ...origin)
-  )
-  return renderedBounds
-}
-
 export function createCropping(context) {
   const croppingWidget = HandlesInPixelsImageCroppingWidget.newInstance()
   context.main.croppingWidget = croppingWidget
   context.main.widgetCroppingPlanes = Array.from({ length: 6 }, () =>
     vtkPlane.newInstance()
   )
-  context.main.areCroppingPlanesTouched = false
   context.itkVtkView.addCroppingWidget(croppingWidget)
 
   croppingWidget
@@ -139,7 +127,7 @@ export function createCropping(context) {
         },
       ]
 
-      // Dont reset planes after user input
+      // Don't reset planes after user input
       context.main.areCroppingPlanesTouched = true
 
       context.service.send({

--- a/src/Rendering/VTKJS/Main/croppingPlanes.js
+++ b/src/Rendering/VTKJS/Main/croppingPlanes.js
@@ -218,7 +218,8 @@ export function addCroppingPlanes(context, actor) {
   })
 }
 
-export function makeCroppable(representationProxy) {
+export function makeCroppable(context, representationProxy) {
   // allows for grabbing crop handles on the other side of volume
   representationProxy.getVolumes().forEach(v => v.setPickable(false))
+  addCroppingPlanes(context, representationProxy)
 }

--- a/src/Rendering/VTKJS/proxyManagerConfiguration.js
+++ b/src/Rendering/VTKJS/proxyManagerConfiguration.js
@@ -1,4 +1,4 @@
-import vtkProxySource from 'vtk.js/Sources/Proxy/Core/SourceProxy'
+import vtkSourceProxy from 'vtk.js/Sources/Proxy/Core/SourceProxy'
 import vtkGeometryRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/GeometryRepresentationProxy'
 import vtkVolumeRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/VolumeRepresentationProxy'
 import vtkSliceRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/SliceRepresentationProxy'
@@ -35,7 +35,7 @@ const proxyManagerConfiguration = {
     },
     Sources: {
       TrivialProducer: {
-        class: vtkProxySource,
+        class: vtkSourceProxy,
         options: {},
       },
     },

--- a/src/Rendering/createRenderingMachine.js
+++ b/src/Rendering/createRenderingMachine.js
@@ -144,6 +144,9 @@ const createRenderingMachine = (options, context) => {
             TOGGLE_IMAGE_INTERPOLATION: {
               actions: forwardTo('images'),
             },
+            IMAGE_COLOR_RANGE_BOUNDS_CHANGED: {
+              actions: forwardTo('images'),
+            },
             IMAGE_COLOR_RANGE_CHANGED: {
               actions: forwardTo('images'),
             },

--- a/src/UI/Images/createImagesUIMachine.js
+++ b/src/UI/Images/createImagesUIMachine.js
@@ -28,7 +28,7 @@ const assignComponentVisibility = assign({
         0
       )
       if (currentNumVisualized + 1 > actorContext.maxIntensityComponents) {
-        // Find the index in the visulized components list of the last touched
+        // Find the index in the visualized components list of the last touched
         // component.  We need to replace it with this component the user just
         // turned on.
         componentVisibilities[
@@ -77,34 +77,6 @@ const assignPiecewiseFunctionPoints = assign({
   images: ({ images }, { data: { component, points, name } }) => {
     const actorContext = images.actorContext.get(name)
     actorContext.piecewiseFunctionPoints.set(component, points)
-    return images
-  },
-})
-
-const assignColorRange = assign({
-  images: (context, event) => {
-    const images = context.images
-    const name = event.data.name
-    const component = event.data.component
-    const range = event.data.range
-
-    const actorContext = context.images.actorContext.get(name)
-    actorContext.colorRanges.set(component, range)
-
-    return images
-  },
-})
-
-const assignColorRangeBounds = assign({
-  images: (context, event) => {
-    const images = context.images
-    const name = event.data.name
-    const component = event.data.component
-    const range = event.data.range
-
-    const actorContext = context.images.actorContext.get(name)
-    actorContext.colorRangeBounds.set(component, range)
-
     return images
   },
 })
@@ -330,13 +302,12 @@ function createImagesUIMachine(options, context) {
             },
             IMAGE_COLOR_RANGE_CHANGED: {
               actions: [
-                assignColorRange,
                 'applyColorRange',
                 forwardTo('transferFunctionManipulators'),
               ],
             },
             IMAGE_COLOR_RANGE_BOUNDS_CHANGED: {
-              actions: [assignColorRangeBounds, 'applyColorRangeBounds'],
+              actions: ['applyColorRangeBounds'],
             },
             IMAGE_COLOR_MAP_SELECTED: {
               actions: assignColorMap,

--- a/src/UI/Layers/createLayersUIMachine.js
+++ b/src/UI/Layers/createLayersUIMachine.js
@@ -202,6 +202,20 @@ const assignImageContext = assign({
       }
     }
 
+    actorContext.colorRangesAutoAdjust = new Map(
+      [...Array(components).keys()].map(c => [c, true]) // { 0: true, 1: true, ... n: true}
+    )
+    actorContext.colorRangeBoundsAutoAdjust = new Map(
+      [...Array(components).keys()].map(c => [c, true])
+    )
+
+    const ranges = image.scaleInfo[image.coarsestScale].ranges ?? []
+    const { colorRanges, colorRangeBounds } = actorContext
+    ranges.forEach((range, component) => {
+      colorRanges.set(component, range)
+      colorRangeBounds.set(component, range)
+    })
+
     images.actorContext.set(name, actorContext)
     return images
   },

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -235,7 +235,7 @@ function createScreenshotButton(context, mainUIRow) {
   mainUIRow.appendChild(screenshotButton)
 }
 
-function _arrayLikeToArray$4(arr, len) {
+function _arrayLikeToArray$3(arr, len) {
   if (len == null || len > arr.length) len = arr.length
 
   for (var i = 0, arr2 = new Array(len); i < len; i++) {
@@ -245,11 +245,11 @@ function _arrayLikeToArray$4(arr, len) {
   return arr2
 }
 
-function _arrayWithoutHoles$1(arr) {
-  if (Array.isArray(arr)) return _arrayLikeToArray$4(arr)
+function _arrayWithoutHoles(arr) {
+  if (Array.isArray(arr)) return _arrayLikeToArray$3(arr)
 }
 
-function _iterableToArray$1(iter) {
+function _iterableToArray(iter) {
   if (
     (typeof Symbol !== 'undefined' && iter[Symbol.iterator] != null) ||
     iter['@@iterator'] != null
@@ -257,28 +257,28 @@ function _iterableToArray$1(iter) {
     return Array.from(iter)
 }
 
-function _unsupportedIterableToArray$4(o, minLen) {
+function _unsupportedIterableToArray$3(o, minLen) {
   if (!o) return
-  if (typeof o === 'string') return _arrayLikeToArray$4(o, minLen)
+  if (typeof o === 'string') return _arrayLikeToArray$3(o, minLen)
   var n = Object.prototype.toString.call(o).slice(8, -1)
   if (n === 'Object' && o.constructor) n = o.constructor.name
   if (n === 'Map' || n === 'Set') return Array.from(o)
   if (n === 'Arguments' || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))
-    return _arrayLikeToArray$4(o, minLen)
+    return _arrayLikeToArray$3(o, minLen)
 }
 
-function _nonIterableSpread$1() {
+function _nonIterableSpread() {
   throw new TypeError(
     'Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.'
   )
 }
 
-function _toConsumableArray$1(arr) {
+function _toConsumableArray(arr) {
   return (
-    _arrayWithoutHoles$1(arr) ||
-    _iterableToArray$1(arr) ||
-    _unsupportedIterableToArray$4(arr) ||
-    _nonIterableSpread$1()
+    _arrayWithoutHoles(arr) ||
+    _iterableToArray(arr) ||
+    _unsupportedIterableToArray$3(arr) ||
+    _nonIterableSpread()
   )
 }
 
@@ -309,7 +309,7 @@ window.addEventListener('load', function() {
     if (body[methods[0]] && fullscreenMethods.length === 0) {
       fullscreenMethods.splice.apply(
         fullscreenMethods,
-        [methods, methods.length].concat(_toConsumableArray$1(methods))
+        [methods, methods.length].concat(_toConsumableArray(methods))
       )
     }
   })
@@ -515,53 +515,6 @@ function createViewPlanesToggle(context, volumeRow) {
     }
   })
   volumeRow.appendChild(viewPlanesButton)
-}
-
-function _arrayLikeToArray$3(arr, len) {
-  if (len == null || len > arr.length) len = arr.length
-
-  for (var i = 0, arr2 = new Array(len); i < len; i++) {
-    arr2[i] = arr[i]
-  }
-
-  return arr2
-}
-
-function _unsupportedIterableToArray$3(o, minLen) {
-  if (!o) return
-  if (typeof o === 'string') return _arrayLikeToArray$3(o, minLen)
-  var n = Object.prototype.toString.call(o).slice(8, -1)
-  if (n === 'Object' && o.constructor) n = o.constructor.name
-  if (n === 'Map' || n === 'Set') return Array.from(o)
-  if (n === 'Arguments' || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))
-    return _arrayLikeToArray$3(o, minLen)
-}
-
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return _arrayLikeToArray$3(arr)
-}
-
-function _iterableToArray(iter) {
-  if (
-    (typeof Symbol !== 'undefined' && iter[Symbol.iterator] != null) ||
-    iter['@@iterator'] != null
-  )
-    return Array.from(iter)
-}
-
-function _nonIterableSpread() {
-  throw new TypeError(
-    'Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.'
-  )
-}
-
-function _toConsumableArray(arr) {
-  return (
-    _arrayWithoutHoles(arr) ||
-    _iterableToArray(arr) ||
-    _unsupportedIterableToArray$3(arr) ||
-    _nonIterableSpread()
-  )
 }
 
 var commonjsGlobal =
@@ -941,44 +894,6 @@ TYPED_ARRAYS.Int16Array = Int16Array
 TYPED_ARRAYS.Uint32Array = Uint32Array
 TYPED_ARRAYS.Int32Array = Int32Array
 TYPED_ARRAYS.Uint8ClampedArray = Uint8ClampedArray // TYPED_ARRAYS.BigInt64Array = BigInt64Array;
-// Creates a throttled function that only invokes `func` at most once per
-// every `wait` milliseconds.
-
-function throttle(callback, delay) {
-  var isThrottled = false
-  var argsToUse = null
-
-  function next() {
-    isThrottled = false
-
-    if (argsToUse !== null) {
-      wrapper.apply(void 0, _toConsumableArray(argsToUse)) // eslint-disable-line
-
-      argsToUse = null
-    }
-  }
-
-  function wrapper() {
-    for (
-      var _len8 = arguments.length, args = new Array(_len8), _key8 = 0;
-      _key8 < _len8;
-      _key8++
-    ) {
-      args[_key8] = arguments[_key8]
-    }
-
-    if (isThrottled) {
-      argsToUse = args
-      return
-    }
-
-    isThrottled = true
-    callback.apply(void 0, args)
-    setTimeout(next, delay)
-  }
-
-  return wrapper
-} // ----------------------------------------------------------------------------
 
 function createPlaneSliders(context) {
   var planeUIGroup = document.createElement('div')
@@ -2536,7 +2451,7 @@ function _slicedToArray(arr, i) {
   return (
     _arrayWithHoles(arr) ||
     _iterableToArrayLimit(arr, i) ||
-    _unsupportedIterableToArray$4(arr, i) ||
+    _unsupportedIterableToArray$3(arr, i) ||
     _nonIterableRest()
   )
 }
@@ -3351,6 +3266,50 @@ function createColorRangeInput(context, imageUIGroup) {
   imageUIGroup.appendChild(colorRangeInputRow)
 }
 
+// from https://stackoverflow.com/a/27078401
+// Trailing call functionality is desired.
+// Returns a function, that, when invoked, will only be triggered at most once
+// during a given window of time. Normally, the throttled function will run
+// as much as it can, without ever going more than once per `wait` duration;
+// but if you'd like to disable the execution on the leading edge, pass
+// `{leading: false}`. To disable execution on the trailing edge, ditto.
+function throttle(func, wait, options) {
+  var context, args, result
+  var timeout = null
+  var previous = 0
+  if (!options) options = {}
+
+  var later = function later() {
+    previous = options.leading === false ? 0 : Date.now()
+    timeout = null
+    result = func.apply(context, args)
+    if (!timeout) context = args = null
+  }
+
+  return function() {
+    var now = Date.now()
+    if (!previous && options.leading === false) previous = now
+    var remaining = wait - (now - previous)
+    context = this
+    args = arguments
+
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+
+      previous = now
+      result = func.apply(context, args)
+      if (!timeout) context = args = null
+    } else if (!timeout && options.trailing !== false) {
+      timeout = setTimeout(later, remaining)
+    }
+
+    return result
+  }
+}
+
 var __defProp = Object.defineProperty
 var __defNormalProp = (obj, key, value) =>
   key in obj
@@ -4032,7 +3991,7 @@ var vtkPiecewiseGaussianWidgetFacade = function vtkPiecewiseGaussianWidgetFacade
       return tfEditor.getPoints()
     },
     setRangeZoom: function setRangeZoom(newRange) {
-      tfEditor.setViewBox.apply(tfEditor, _toConsumableArray$1(newRange))
+      tfEditor.setViewBox.apply(tfEditor, _toConsumableArray(newRange))
     },
     setHistogram: function setHistogram(h) {
       return tfEditor.setHistogram(h)
@@ -4738,37 +4697,6 @@ function updateAvailableComponents(context) {
   }
 }
 
-function applyColorRangeBounds(context, event) {
-  var name = event.data.name
-  var componentIndex = event.data.component
-  var actorContext = context.images.actorContext.get(name)
-
-  if (
-    name !== context.images.selectedName ||
-    componentIndex !== actorContext.selectedComponent
-  ) {
-    return
-  }
-
-  var range = event.data.range
-  var minimumInput = context.images.colorRangeInputRow.children[0]
-  var maximumInput = context.images.colorRangeInputRow.children[2]
-  minimumInput.min = range[0]
-  minimumInput.max = range[1]
-  maximumInput.min = range[0]
-  maximumInput.max = range[1]
-  var image = actorContext.image
-
-  if (
-    (image && image.imageType.componentType === 'float') ||
-    image.imageType.componentType === 'double'
-  ) {
-    var step = (range[1] - range[0]) / 1000.0
-    minimumInput.step = step
-    maximumInput.step = step
-  }
-}
-
 function applyColorRange(context, event) {
   var name = event.data.name
   var component = event.data.component
@@ -4792,12 +4720,60 @@ function applyColorRange(context, event) {
     fullRange = actorContext.colorRangeBounds.get(component)
   }
 
+  if (event.data.fullRange) {
+    // use more up to date colorRangeBounds
+    fullRange = event.data.fullRange
+  }
+
   var diff = fullRange[1] - fullRange[0]
   var colorRangeNormalized = [
     (colorRange[0] - fullRange[0]) / diff,
     (colorRange[1] - fullRange[0]) / diff,
   ]
   context.images.transferFunctionWidget.setRangeZoom(colorRangeNormalized)
+}
+
+function applyColorRangeBounds(context, event) {
+  var _event$data = event.data,
+    name = _event$data.name,
+    component = _event$data.component
+  var actorContext = context.images.actorContext.get(name)
+
+  if (
+    name !== context.images.selectedName ||
+    component !== actorContext.selectedComponent
+  ) {
+    return
+  }
+
+  var range = event.data.range
+  var minimumInput = context.images.colorRangeInputRow.children[0]
+  var maximumInput = context.images.colorRangeInputRow.children[2]
+  minimumInput.min = range[0]
+  minimumInput.max = range[1]
+  maximumInput.min = range[0]
+  maximumInput.max = range[1]
+  var image = actorContext.image
+
+  if (
+    (image && image.imageType.componentType === 'float') ||
+    image.imageType.componentType === 'double'
+  ) {
+    var step = (range[1] - range[0]) / 1000.0
+    minimumInput.step = step
+    maximumInput.step = step
+  }
+
+  if (actorContext.colorRanges.has(component)) {
+    applyColorRange(context, {
+      data: {
+        name: name,
+        component: component,
+        range: actorContext.colorRanges.get(component),
+        fullRange: range,
+      },
+    })
+  }
 }
 
 function applyColorMap(context, _ref) {
@@ -5100,7 +5076,6 @@ function selectImageComponent(context, event) {
   }
 
   if (actorContext.colorRangeBounds.has(component)) {
-    // calls transferFunctionWidget.setDataRange(range)
     applyColorRangeBounds(context, {
       data: {
         name: name,
@@ -5216,7 +5191,7 @@ function applyScaleCount(input, scaleCount) {
   autoPickOption.innerHTML = 'Framerate-pick'
   input.appendChild(autoPickOption)
 
-  _toConsumableArray$1(Array(scaleCount).keys())
+  _toConsumableArray(Array(scaleCount).keys())
     .reverse()
     .forEach(function(i) {
       var option = document.createElement('option')

--- a/src/UI/reference-ui/src/Images/applyColorRange.js
+++ b/src/UI/reference-ui/src/Images/applyColorRange.js
@@ -22,6 +22,10 @@ function applyColorRange(context, event) {
   if (actorContext.colorRangeBounds.has(component)) {
     fullRange = actorContext.colorRangeBounds.get(component)
   }
+  if (event.data.fullRange) {
+    // use more up to date colorRangeBounds
+    fullRange = event.data.fullRange
+  }
   const diff = fullRange[1] - fullRange[0]
 
   const colorRangeNormalized = [

--- a/src/UI/reference-ui/src/Images/applyColorRangeBounds.js
+++ b/src/UI/reference-ui/src/Images/applyColorRangeBounds.js
@@ -1,11 +1,12 @@
+import applyColorRange from './applyColorRange'
+
 function applyColorRangeBounds(context, event) {
-  const name = event.data.name
-  const componentIndex = event.data.component
+  const { name, component } = event.data
   const actorContext = context.images.actorContext.get(name)
 
   if (
     name !== context.images.selectedName ||
-    componentIndex !== actorContext.selectedComponent
+    component !== actorContext.selectedComponent
   ) {
     return
   }
@@ -28,6 +29,17 @@ function applyColorRangeBounds(context, event) {
     const step = (range[1] - range[0]) / 1000.0
     minimumInput.step = step
     maximumInput.step = step
+  }
+
+  if (actorContext.colorRanges.has(component)) {
+    applyColorRange(context, {
+      data: {
+        name,
+        component,
+        range: actorContext.colorRanges.get(component),
+        fullRange: range,
+      },
+    })
   }
 }
 

--- a/src/UI/reference-ui/src/Images/createTransferFunctionEditor.js
+++ b/src/UI/reference-ui/src/Images/createTransferFunctionEditor.js
@@ -1,4 +1,4 @@
-import { throttle } from '@kitware/vtk.js/macros'
+import { throttle } from './throttle'
 import { TransferFunctionEditor } from 'itk-viewer-transfer-function-editor'
 
 const PIECEWISE_UPDATE_DELAY = 100

--- a/src/UI/reference-ui/src/Images/selectImageComponent.js
+++ b/src/UI/reference-ui/src/Images/selectImageComponent.js
@@ -31,7 +31,6 @@ function selectImageComponent(context, event) {
   }
 
   if (actorContext.colorRangeBounds.has(component)) {
-    // calls transferFunctionWidget.setDataRange(range)
     applyColorRangeBounds(context, {
       data: {
         name,

--- a/src/UI/reference-ui/src/Images/throttle.js
+++ b/src/UI/reference-ui/src/Images/throttle.js
@@ -1,0 +1,39 @@
+// from https://stackoverflow.com/a/27078401
+
+// Trailing call functionality is desired.
+// Returns a function, that, when invoked, will only be triggered at most once
+// during a given window of time. Normally, the throttled function will run
+// as much as it can, without ever going more than once per `wait` duration;
+// but if you'd like to disable the execution on the leading edge, pass
+// `{leading: false}`. To disable execution on the trailing edge, ditto.
+export function throttle(func, wait, options) {
+  var context, args, result
+  var timeout = null
+  var previous = 0
+  if (!options) options = {}
+  var later = function() {
+    previous = options.leading === false ? 0 : Date.now()
+    timeout = null
+    result = func.apply(context, args)
+    if (!timeout) context = args = null
+  }
+  return function() {
+    var now = Date.now()
+    if (!previous && options.leading === false) previous = now
+    var remaining = wait - (now - previous)
+    context = this
+    args = arguments
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      previous = now
+      result = func.apply(context, args)
+      if (!timeout) context = args = null
+    } else if (!timeout && options.trailing !== false) {
+      timeout = setTimeout(later, remaining)
+    }
+    return result
+  }
+}

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -234,20 +234,6 @@ const createViewer = async (
     const multiscaleImage = await toMultiscaleSpatialImage(image)
     imageName = multiscaleImage?.name ?? null
     service.send({ type: 'ADD_IMAGE', data: multiscaleImage })
-    if (multiscaleImage.scaleInfo[0].ranges) {
-      const components = multiscaleImage.imageType.components
-      for (let comp = 0; comp < components; comp++) {
-        const range = multiscaleImage.scaleInfo[0].ranges[comp]
-        service.send({
-          type: 'IMAGE_COLOR_RANGE_CHANGED',
-          data: { name: imageName, component: comp, range },
-        })
-        service.send({
-          type: 'IMAGE_COLOR_RANGE_BOUNDS_CHANGED',
-          data: { name: imageName, component: comp, range },
-        })
-      }
-    }
   }
 
   if (labelImage) {
@@ -711,20 +697,6 @@ const createViewer = async (
       service.send({ type: 'IMAGE_ASSIGNED', data: name })
     } else {
       service.send({ type: 'ADD_IMAGE', data: multiscaleImage })
-      if (multiscaleImage.scaleInfo[0].ranges) {
-        const components = multiscaleImage.imageType.components
-        for (let comp = 0; comp < components; comp++) {
-          const range = multiscaleImage.scaleInfo[0].ranges[comp]
-          service.send({
-            type: 'IMAGE_COLOR_RANGE_CHANGED',
-            data: { name, component: comp, range },
-          })
-          service.send({
-            type: 'IMAGE_COLOR_RANGE_BOUNDS_CHANGED',
-            data: { name, component: comp, range },
-          })
-        }
-      }
     }
   }
 

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -110,7 +110,7 @@ test('Test createViewer', async t => {
     image: itkImage,
     labelImage: itkLabelImage,
     rotate: false,
-    gradientOpacity: 0.1,
+    gradientOpacity: GRADIENT_OPACITY,
     config: { uiMachineOptions },
   })
   viewer.setRenderingViewContainerStyle(TEST_VIEWER_STYLE.containerStyle)


### PR DESCRIPTION
For the world bounds passed to `MultiscaleSpatialImage.getImage()`, `updateRenderedImage()` intersects the world axis aligned bounding box of the camera frustum with the cropping planes.  Camera modified events trigger `updateRenderedImage()` after debounce.

Changes colorRange and colorRangeBounds to automatically grow after loading more image data.  As image scales become finer, intensity extremes emerge. If the colorRange/colorRangeBounds are changed by the UI or API, they are "touched" and don't automatically change as new data is loaded. Before was calculating the range of data just once on the coarsest scale.  However, that may have had a better result for visualization by clipping the extremes in the transfer functions.  