### PR TITLE
feat(imjoyplugin): support creation of empty viewer

### DIFF
--- a/src/imJoyPluginAPI.js
+++ b/src/imJoyPluginAPI.js
@@ -43,6 +43,15 @@ const imJoyPluginAPI = {
       } else {
         await this.setPointSets(ctx.data.pointSets)
       }
+    } else if (ctx.data && ctx.config) {
+      this.viewer = await itkVtkViewer.createViewer(container, {
+        image: null,
+        labelImage: null,
+        pointSets: null,
+        geometries: null,
+        rotate: false,
+        config: ctx.config,
+      })
     }
   },
 


### PR DESCRIPTION
From `itkwidgets` allows users to create an empty viewer before setting any data. For example:
```
viewer = view()

viewer.setImage(img)
```