### PR TITLE
fix(setimage): prevent image name from being set to undefined

### DIFF
--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -702,9 +702,7 @@ const createViewer = async (
   }
 
   publicAPI.setImage = async (image, name) => {
-    if (typeof name === 'undefined' && context.images.selectedName) {
-      name = context.images.selectedName
-    }
+    name = name ?? context.images?.selectedName ?? 'Image'
     const multiscaleImage = await toMultiscaleSpatialImage(image)
     multiscaleImage.name = name
     if (context.images.actorContext.has(name)) {


### PR DESCRIPTION
If `setImage` is called with no previous data set the image name is `undefined` which creates errors further down the pipeline. Always use a string as the image name.