### PR TITLE
Rotate and color ranges bugs

### DIFF
--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -340,6 +340,8 @@ const createImageRenderingActor = (options, context /*, event*/) => {
             FPS_UPDATED: {
               actions: forwardTo('updatingImageMachine'),
             },
+            CROPPING_PLANES_CHANGED_BY_USER: {},
+            CAMERA_MODIFIED: {},
           },
           invoke: {
             id: 'updatingImageMachine',

--- a/src/Rendering/VTKJS/Images/updateRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/updateRenderedImage.js
@@ -74,7 +74,7 @@ async function updateRenderedImage(context) {
     imageAtScale.imageType.components !==
       actorContext.visualizedComponents.length // more components in image than renderable
 
-  const [itkImage, componentRanges] = isFuseNeeded
+  const [itkImage, computedComponentRanges] = isFuseNeeded
     ? await fuseImages({
         imageAtScale,
         labelAtScale,
@@ -88,6 +88,11 @@ async function updateRenderedImage(context) {
         ),
       ]
 
+  const componentRanges =
+    image?.scaleInfo[targetScale].ranges?.map(([min, max]) => ({
+      min,
+      max,
+    })) ?? computedComponentRanges
   const vtkImage = vtkITKHelper.convertItkToVtkImage(itkImage)
   return {
     itkImage,

--- a/src/UI/Layers/createLayersUIMachine.js
+++ b/src/UI/Layers/createLayersUIMachine.js
@@ -209,13 +209,6 @@ const assignImageContext = assign({
       [...Array(components).keys()].map(c => [c, true])
     )
 
-    const ranges = image.scaleInfo[image.coarsestScale].ranges ?? []
-    const { colorRanges, colorRangeBounds } = actorContext
-    ranges.forEach((range, component) => {
-      colorRanges.set(component, range)
-      colorRangeBounds.set(component, range)
-    })
-
     images.actorContext.set(name, actorContext)
     return images
   },


### PR DESCRIPTION
Fixes bugs when rotate=true and data has preset ranges.

When rotate=true, ImageRenderingActor machine would switch out of loading state to camera debouce state and thus ignore return value of updateRenderedImage.  Would never apply the loaded image.

If the data had colorRanges preset, Layer machine would set actorcontext.colorRanges, but no change would be detected in applyRendereImage and the transfer function objects applyRendereImage creates would not get updated.