### PR TITLE
If image loaded after labelImage, reuse actorContext

### DIFF
--- a/dist/testConglomerate.html
+++ b/dist/testConglomerate.html
@@ -25,18 +25,20 @@
         )
         const container = document.querySelector('#viewport')
         const viewer = await itkVtkViewer.createViewer(container, {
-          image,
+          // image,
           rotate: false,
         })
 
-        viewer.setLabelImage(
+        viewer.setImage(image)
+        // need the await for the setImagePiecewiseFunctionPoints to take
+        await viewer.setLabelImage(
           new URL('test-data/HeadMRVolumeLabels.nrrd', window.location.origin)
         )
 
         const newPoints = [
           [0, 0],
-          [0.5, 0.5],
-          [1, 1],
+          [0.75, 0.9],
+          [0.9, 1],
         ]
         viewer.setImagePiecewiseFunctionPoints(newPoints, 0)
         window.viewer = viewer

--- a/src/Rendering/VTKJS/Images/applyColorMap.js
+++ b/src/Rendering/VTKJS/Images/applyColorMap.js
@@ -1,21 +1,17 @@
 import vtkLookupTableProxy from 'vtk.js/Sources/Proxy/Core/LookupTableProxy'
 
-function applyColorMap(context, event) {
-  const name = event.data.name
-  const component = event.data.component
+function applyColorMap(context, { data: { name, colorMap, component } }) {
   const actorContext = context.images.actorContext.get(name)
 
-  const colorMap = event.data.colorMap
+  const lookupTableProxy = context.images.lookupTableProxies?.get(component)
 
-  const lookupTableProxy = context.images.lookupTableProxies.get(component)
-  const colorTransferFunction = lookupTableProxy.getLookupTable()
-
-  const currentColorMap = lookupTableProxy.getPresetName()
-  if (currentColorMap !== colorMap) {
+  const currentColorMap = lookupTableProxy?.getPresetName()
+  if (currentColorMap && currentColorMap !== colorMap) {
     lookupTableProxy.setPresetName(colorMap)
     lookupTableProxy.setMode(vtkLookupTableProxy.Mode.Preset)
     if (actorContext.colorRanges.has(component)) {
       const range = actorContext.colorRanges.get(component)
+      const colorTransferFunction = lookupTableProxy.getLookupTable()
       colorTransferFunction.setMappingRange(range[0], range[1])
       colorTransferFunction.updateRange()
     }

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -156,10 +156,9 @@ function applyRenderedImage(context, { data: { name } }) {
 
   // Create color map and piecewise function objects as needed
   for (let component = 0; component < numberOfComponents; component++) {
-    if (context.images.lookupTableProxies.has(component)) {
-      continue
-    }
-    const lookupTableProxy = vtkLookupTableProxy.newInstance()
+    const lookupTableProxy =
+      context.images.lookupTableProxies.get(component) ??
+      vtkLookupTableProxy.newInstance()
 
     const lut = lookupTableProxy.getLookupTable()
     if (actorContext.colorRanges.has(component)) {
@@ -268,8 +267,10 @@ function applyRenderedImage(context, { data: { name } }) {
       if (!componentsVisible) {
         mode = OpacityMode.FRACTIONAL
       }
-      const numberOfComponents = actorContext.componentVisibilities.length
-      volumeProperty.setOpacityMode(numberOfComponents, mode)
+      const labelMapComponentIndex = actorContext.visualizedComponents.indexOf(
+        -1
+      )
+      volumeProperty.setOpacityMode(labelMapComponentIndex, mode)
     }
   })
 

--- a/src/Rendering/VTKJS/Images/updateVisualizedComponents.js
+++ b/src/Rendering/VTKJS/Images/updateVisualizedComponents.js
@@ -5,12 +5,10 @@ function updateVisualizedComponents(context, name) {
   const editorLabelImage = actorContext.editorLabelImage
   if (image) {
     const imageComponents = image.imageType.components
-    if (typeof actorContext.visualizedComponents === 'undefined') {
-      actorContext.visualizedComponents = Array(image.imageType.components)
-        .fill(0)
-        .map((_, idx) => idx)
-        .filter(i => actorContext.componentVisibilities[i])
-    }
+    actorContext.visualizedComponents = Array(image.imageType.components)
+      .fill(0)
+      .map((_, idx) => idx)
+      .filter(i => actorContext.componentVisibilities[i])
 
     actorContext.maxIntensityComponents = 4
     if (labelImage) {
@@ -42,15 +40,8 @@ function updateVisualizedComponents(context, name) {
     }
   }
   if (labelImage) {
-    if (typeof actorContext.visualizedComponents === 'undefined') {
-      actorContext.visualizedComponents = [-1]
-    } else if (
-      actorContext.visualizedComponents[
-        actorContext.visualizedComponents.length - 1
-      ] !== -1
-    ) {
-      actorContext.visualizedComponents.push(-1)
-    }
+    actorContext.visualizedComponents = actorContext.visualizedComponents ?? []
+    actorContext.visualizedComponents.push(-1)
   }
 }
 

--- a/src/UI/reference-ui/dist/referenceUIMachineOptions.js
+++ b/src/UI/reference-ui/dist/referenceUIMachineOptions.js
@@ -2273,10 +2273,11 @@ function selectLayer(context, event) {
   }
 
   if (!context.uiCollapsed) {
+    var imageActorContext = actorContext.imageActorContext
+
     switch (type) {
       case 'image':
         applyGroupVisibility(context, ['images'], true)
-        var imageActorContext = context.images.actorContext.get(name)
 
         if (imageActorContext.labelImageName) {
           applyGroupVisibility(

--- a/src/UI/reference-ui/src/Layers/selectLayer.js
+++ b/src/UI/reference-ui/src/Layers/selectLayer.js
@@ -26,10 +26,10 @@ function selectLayer(context, event) {
   }
 
   if (!context.uiCollapsed) {
+    const { imageActorContext } = actorContext
     switch (type) {
       case 'image':
         applyGroupVisibility(context, ['images'], true)
-        const imageActorContext = context.images.actorContext.get(name)
         if (imageActorContext.labelImageName) {
           applyGroupVisibility(
             context,

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -687,8 +687,8 @@ const createViewer = async (
     context.service.send({ type: 'SELECT_LAYER', data: name })
   }
 
-  publicAPI.setImage = async (image, name) => {
-    name = name ?? context.images?.selectedName ?? 'Image'
+  publicAPI.setImage = async (image, imageName) => {
+    const name = imageName ?? context.images?.selectedName ?? 'Image'
     const multiscaleImage = await toMultiscaleSpatialImage(image)
     multiscaleImage.name = name
     if (context.images.actorContext.has(name)) {

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -518,6 +518,50 @@ test('Test createViewer with just labelImage', async t => {
   })
 })
 
+test('Test setImage and setLabelImage after createViewer', async t => {
+  const gc = testUtils.createGarbageCollector(t)
+
+  const container = document.querySelector('body')
+  const viewerContainer = gc.registerDOMElement(document.createElement('div'))
+  container.appendChild(viewerContainer)
+
+  const labelImageResponse = await axios.get(testLabelImage3DPath, {
+    responseType: 'arraybuffer',
+  })
+  const { image: labelImage, webWorker } = await readImageArrayBuffer(
+    null,
+    labelImageResponse.data,
+    'data.nrrd'
+  )
+  webWorker.terminate()
+
+  const imageResponse = await axios.get(testImage3DPath, {
+    responseType: 'arraybuffer',
+  })
+
+  const { image, webWorker: webWorkerForImage } = await readImageArrayBuffer(
+    null,
+    imageResponse.data,
+    'data.nrrd'
+  )
+  webWorkerForImage.terminate()
+
+  const viewer = await createViewer(container, {
+    rotate: false,
+  })
+
+  viewer.setImage(image)
+  viewer.setLabelImage(labelImage)
+
+  t.plan(1)
+  viewer.once('renderedImageAssigned', () => {
+    t.pass(
+      'createViewer did not crash with with late setImage and setLabelImage'
+    )
+    gc.releaseResources()
+  })
+})
+
 test('Test createViewer custom UI options', async t => {
   const gc = testUtils.createGarbageCollector(t)
 


### PR DESCRIPTION
Fixes case when setImage and setLabelImage happen after createViewer
```
const viewer = await itkVtkViewer.createViewer(container)
viewer.setImage(image)
viewer.setLabelImage(labelImage)
```