### PR TITLE
Laggy Slice Slider Fix and Out of Memory Catching

### DIFF
--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -109,7 +109,9 @@ const assignIsFramerateScalePickingOn = assign({
 
 const KNOWN_ERRORS = [
   'Voxel count over max at scale',
-  "DataCloneError: Failed to execute 'postMessage' on 'Worker': Data cannot be cloned, out of memory.",
+  "Failed to execute 'postMessage' on 'Worker': Data cannot be cloned, out of memory.",
+  "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Data cannot be cloned, out of memory.",
+  'Array buffer allocation failed',
 ]
 
 const checkIsKnownErrorOrThrow = (c, { data: error }) => {

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -73,11 +73,6 @@ function applyRenderedImage(context, { data: { name } }) {
 
   context.images.source.setInputData(actorContext.fusedImage)
 
-  const savedSlicePositions = context.images.representationProxy && [
-    context.images.representationProxy.getXSlice(),
-    context.images.representationProxy.getYSlice(),
-    context.images.representationProxy.getZSlice(),
-  ]
   // VTK.js currently only supports a single image
   if (!context.images.representationProxy) {
     context.proxyManager.createRepresentationInAllViews(context.images.source)
@@ -136,7 +131,9 @@ function applyRenderedImage(context, { data: { name } }) {
   const { representationProxy } = context.images
 
   // undo representationProxy.setInput calling volume.setVisibility(false) if it finds dimensions === 2 (may have just been cropped)
-  representationProxy.setVolumeVisibility(!context.use2D)
+  representationProxy.setVolumeVisibility(
+    !context.use2D && context.main.viewMode === 'Volume'
+  )
 
   // triggers update of ImageSliceOutlines if fusedImage size changed
   representationProxy.getActors().forEach(actor => actor.getMapper().modified())

--- a/src/Rendering/VTKJS/Images/fuseImagesUtils.js
+++ b/src/Rendering/VTKJS/Images/fuseImagesUtils.js
@@ -50,9 +50,10 @@ export const fuseComponents = ({ componentInfo, arrayToFill }) => {
   return fusedImageData
 }
 
-export const computeRanges = async (imageData, numberOfComponents) =>
-  await Promise.all(
-    [...Array(numberOfComponents).keys()].map(comp =>
-      computeRange(imageData, comp, numberOfComponents)
-    )
-  )
+export const computeRanges = async (imageData, numberOfComponents) => {
+  const ranges = []
+  for (let compIdx = 0; compIdx < numberOfComponents; compIdx++) {
+    ranges.push(await computeRange(imageData, compIdx, numberOfComponents))
+  }
+  return ranges
+}

--- a/src/Rendering/VTKJS/Main/applyXSlice.js
+++ b/src/Rendering/VTKJS/Main/applyXSlice.js
@@ -4,7 +4,7 @@ function applyXSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setXSlice(Number(position))
-    context.service.send('RENDER')
+    context.service.send('RENDER_LATER')
   }
 }
 

--- a/src/Rendering/VTKJS/Main/applyYSlice.js
+++ b/src/Rendering/VTKJS/Main/applyYSlice.js
@@ -4,7 +4,7 @@ function applyYSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setYSlice(Number(position))
-    context.service.send('RENDER')
+    context.service.send('RENDER_LATER')
   }
 }
 

--- a/src/Rendering/VTKJS/Main/applyZSlice.js
+++ b/src/Rendering/VTKJS/Main/applyZSlice.js
@@ -4,7 +4,7 @@ function applyZSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setZSlice(Number(position))
-    context.service.send('RENDER')
+    context.service.send('RENDER_LATER')
   }
 }
 

--- a/src/Rendering/VTKJS/renderLater.js
+++ b/src/Rendering/VTKJS/renderLater.js
@@ -1,0 +1,7 @@
+function renderLater(context) {
+  if (!context.renderWindow.getInteractor().isAnimating()) {
+    context.itkVtkView.renderLater()
+  }
+}
+
+export default renderLater

--- a/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
@@ -1,5 +1,6 @@
 import createRenderer from './createRenderer'
 import render from './render'
+import renderLater from './renderLater'
 import requestAnimation from './requestAnimation'
 import cancelAnimation from './cancelAnimation'
 
@@ -21,6 +22,7 @@ const vtkJSRenderingMachineOptions = {
     createRenderer,
 
     render,
+    renderLater,
     requestAnimation,
     cancelAnimation,
   },

--- a/src/Rendering/createRenderingMachine.js
+++ b/src/Rendering/createRenderingMachine.js
@@ -52,6 +52,9 @@ const createRenderingMachine = (options, context) => {
             RENDER: {
               actions: 'render',
             },
+            RENDER_LATER: {
+              actions: 'renderLater',
+            },
             UPDATE_FPS: {
               actions: forwardTo('main'),
             },

--- a/src/createViewerMachine.js
+++ b/src/createViewerMachine.js
@@ -301,6 +301,9 @@ const createViewerMachine = (options, context, eventEmitterCallback) => {
             RENDER: {
               actions: forwardTo('rendering'),
             },
+            RENDER_LATER: {
+              actions: forwardTo('rendering'),
+            },
             UPDATE_FPS: {
               actions: forwardTo('rendering'),
             },


### PR DESCRIPTION
After adding this line
https://github.com/Kitware/itk-vtk-viewer/blob/67915784ef42d03e21c5c8e4b69f980352e7990f/src/Rendering/VTKJS/Images/applyRenderedImage.js#L134
Slider steps were updated every scale to the image spacing.  Synchronous window.render calls became bottlenecks.  This PR changes to asynchronous render calls.

Also catches more out of memory errors when loading images. 