### PR TITLE
Throttle render

### DIFF
--- a/src/Rendering/VTKJS/Images/applyCinematicChanged.js
+++ b/src/Rendering/VTKJS/Images/applyCinematicChanged.js
@@ -48,5 +48,5 @@ export function applyCinematicChanged(context, { actorContext }) {
     }
   })
 
-  context.service.send('RENDER_LATER')
+  context.service.send('RENDER')
 }

--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -141,8 +141,6 @@ function applyRenderedImage(context, { data: { name } }) {
   // call after representations are created
   updateCroppingParametersFromImage(context, actorContext.fusedImage)
 
-  context.itkVtkView.getRenderer().resetCameraClippingRange()
-
   // Create color map and piecewise function objects as needed
   if (typeof context.images.lookupTableProxies === 'undefined') {
     context.images.lookupTableProxies = new Map()

--- a/src/Rendering/VTKJS/Images/assignRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/assignRenderedImage.js
@@ -52,6 +52,11 @@ const assignRenderedImage = assign({
     componentRanges.forEach((range, comp) =>
       fusedImageScalars.setRange(range, comp)
     )
+
+    // Keeps ProxyRepresentation's call of fusedImageScalars.getRange() from slow computation of "magnitude" combination of components
+    // We don't use.
+    fusedImageScalars.setRange({ min: 0, max: 1 }, numberOfComponents)
+
     // Trigger VolumeMapper scalarTexture update
     fusedImage.modified()
 

--- a/src/Rendering/VTKJS/Main/applyXSlice.js
+++ b/src/Rendering/VTKJS/Main/applyXSlice.js
@@ -4,7 +4,7 @@ function applyXSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setXSlice(Number(position))
-    context.service.send('RENDER_LATER')
+    context.service.send('RENDER')
   }
 }
 

--- a/src/Rendering/VTKJS/Main/applyYSlice.js
+++ b/src/Rendering/VTKJS/Main/applyYSlice.js
@@ -4,7 +4,7 @@ function applyYSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setYSlice(Number(position))
-    context.service.send('RENDER_LATER')
+    context.service.send('RENDER')
   }
 }
 

--- a/src/Rendering/VTKJS/Main/applyZSlice.js
+++ b/src/Rendering/VTKJS/Main/applyZSlice.js
@@ -4,7 +4,7 @@ function applyZSlice(context, event) {
   const volumeRep = context.images.representationProxy
   if (volumeRep) {
     volumeRep.setZSlice(Number(position))
-    context.service.send('RENDER_LATER')
+    context.service.send('RENDER')
   }
 }
 

--- a/src/Rendering/VTKJS/Main/setBackgroundColor.js
+++ b/src/Rendering/VTKJS/Main/setBackgroundColor.js
@@ -4,7 +4,7 @@ function setBackgroundColor(context, event) {
   }
   const backgroundColor = context.main.backgroundColor
   context.itkVtkView.setBackground(backgroundColor)
-  context.renderWindow.render()
+  context.service.send('RENDER')
 }
 
 export default setBackgroundColor

--- a/src/Rendering/VTKJS/renderLater.js
+++ b/src/Rendering/VTKJS/renderLater.js
@@ -1,7 +1,0 @@
-function renderLater(context) {
-  if (!context.renderWindow.getInteractor().isAnimating()) {
-    context.itkVtkView.renderLater()
-  }
-}
-
-export default renderLater

--- a/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
@@ -1,6 +1,5 @@
 import createRenderer from './createRenderer'
 import render from './render'
-import renderLater from './renderLater'
 import requestAnimation from './requestAnimation'
 import cancelAnimation from './cancelAnimation'
 
@@ -25,7 +24,6 @@ const vtkJSRenderingMachineOptions = {
     createRenderer,
 
     render,
-    renderLater,
     requestAnimation,
     cancelAnimation,
   },

--- a/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
+++ b/src/Rendering/VTKJS/vtkJSRenderingMachineOptions.js
@@ -9,6 +9,9 @@ import layersRenderingMachineOptions from './Layers/layersRenderingMachineOption
 import imagesRenderingMachineOptions from './Images/imagesRenderingMachineOptions'
 import widgetsRenderingMachineOptions from './Widgets/widgetsRenderingMachineOptions'
 
+const isNotAnimating = context =>
+  !context.renderWindow.getInteractor().isAnimating()
+
 const vtkJSRenderingMachineOptions = {
   main: mainRenderingMachineOptions,
 
@@ -25,6 +28,10 @@ const vtkJSRenderingMachineOptions = {
     renderLater,
     requestAnimation,
     cancelAnimation,
+  },
+
+  guards: {
+    isNotAnimating,
   },
 }
 

--- a/src/UI/reference-ui/src/Images/toggleUseShadow.js
+++ b/src/UI/reference-ui/src/Images/toggleUseShadow.js
@@ -8,7 +8,7 @@ function toggleUseShadow(context, event) {
   context.images.useShadowButtonInput.checked = useShadow
 
   context.imageUI.representationProxy.setUseShadow(useShadow)
-  context.renderWindow.render()
+  context.service.send('RENDER')
 }
 
 export default toggleUseShadow

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -394,11 +394,9 @@ const createViewer = async (
 
   UserInterface.addLogo(store)
 
-  publicAPI.renderLater = () => {
-    store.itkVtkView.renderLater()
+  publicAPI.render = () => {
+    service.send('RENDER')
   }
-
-  const viewerDOMId = store.id
 
   // The `store` is considered an internal implementation detail
   // and its interface and behavior may change without changes to the major version.

--- a/src/createViewerMachine.js
+++ b/src/createViewerMachine.js
@@ -301,9 +301,6 @@ const createViewerMachine = (options, context, eventEmitterCallback) => {
             RENDER: {
               actions: forwardTo('rendering'),
             },
-            RENDER_LATER: {
-              actions: forwardTo('rendering'),
-            },
             UPDATE_FPS: {
               actions: forwardTo('rendering'),
             },

--- a/src/index.js
+++ b/src/index.js
@@ -172,10 +172,7 @@ export function initializeEmbeddedViewers() {
         }
 
         viewer.setUICollapsed(true)
-        // Render
-        if (viewer.renderWindow && viewer.renderWindow.render) {
-          viewer.renderWindow.render()
-        }
+        viewer.render()
         el.dataset.viewer = viewer
       })
     }

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -244,7 +244,7 @@ test('Test createViewer', async t => {
   const renderWindow = viewProxy.getOpenglRenderWindow()
   // Consistent baseline image size for regression testing
   renderWindow.setSize(600, 600)
-  viewer.renderLater()
+  viewer.render()
   setTimeout(async () => {
     viewer.once('imageColorRangeChanged', () => {
       t.pass('imageColorRangeChanged event')
@@ -470,7 +470,7 @@ test('Test createViewer.setImage', async t => {
   renderWindow.setSize(600, 600)
   const representation = viewProxy.getRepresentations()[0]
   /*const volumeMapper = */ representation.getMapper()
-  viewer.renderLater()
+  viewer.render()
   setTimeout(() => {
     viewer.captureImage().then(
       (/*screenshot*/) => {


### PR DESCRIPTION
Removes RENDER_LATER.  Adds throttling logic to RENDER:
1. `send("RENER")` from somewhere
2. RenderingMachine gets event and calls render
3. RenderingMachine waits for requestAnimationFrame and one tick via setTimeout to try to wait until after paint
4.  Any `send("RENER")` from anywhere, before above timeout fires, transitions from state waitingForRequest to renderRequested.
5. Throttle setTimeout fires and if in renderRequested, call render

closes #576 