### PR TITLE
Handle URLs with options and refactor fetchBinaryContent API

### DIFF
--- a/src/IO/fetchBinaryContent.js
+++ b/src/IO/fetchBinaryContent.js
@@ -1,8 +1,7 @@
 import axios from 'axios'
 import any from 'promise.any'
 
-async function fetchBinaryContent(url, progressCallback) {
-  const urlObj = new URL(url, document.location)
+async function fetchBinaryContent(urlObj, progressCallback) {
   if (urlObj.protocol === 'ipfs:') {
     const splitPathname = urlObj.href.split('/')
     const cid = splitPathname[2]

--- a/src/IO/toMultiscaleSpatialImage.js
+++ b/src/IO/toMultiscaleSpatialImage.js
@@ -65,7 +65,7 @@ async function toMultiscaleSpatialImage(image, isLabelImage = false) {
       const { image: itkImage, webWorker } = await readImageArrayBuffer(
         null,
         dataBuffer,
-        image.pathname.split('/').at(-1)
+        image.pathname.split('/').pop()
       )
       webWorker.terminate()
       multiscaleImage = await itkImageToInMemoryMultiscaleSpatialImage(

--- a/src/IO/toMultiscaleSpatialImage.js
+++ b/src/IO/toMultiscaleSpatialImage.js
@@ -61,7 +61,7 @@ async function toMultiscaleSpatialImage(image, isLabelImage = false) {
     if (isZarr(image.href)) {
       multiscaleImage = ZarrMultiscaleSpatialImage.fromUrl(image)
     } else {
-      const dataBuffer = await fetchBinaryContent(image.href)
+      const dataBuffer = await fetchBinaryContent(image)
       const { image: itkImage, webWorker } = await readImageArrayBuffer(
         null,
         dataBuffer,

--- a/src/IO/toMultiscaleSpatialImage.js
+++ b/src/IO/toMultiscaleSpatialImage.js
@@ -58,15 +58,14 @@ async function toMultiscaleSpatialImage(image, isLabelImage = false) {
       isLabelImage
     )
   } else if (image.href !== undefined) {
-    const imageHref = image.href
     if (isZarr(image.href)) {
       multiscaleImage = ZarrMultiscaleSpatialImage.fromUrl(image)
     } else {
-      const dataBuffer = await fetchBinaryContent(imageHref)
+      const dataBuffer = await fetchBinaryContent(image.href)
       const { image: itkImage, webWorker } = await readImageArrayBuffer(
         null,
         dataBuffer,
-        imageHref.split('/').slice(-1)[0]
+        image.pathname.split('/').at(-1)
       )
       webWorker.terminate()
       multiscaleImage = await itkImageToInMemoryMultiscaleSpatialImage(

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ async function makeImage({ image, progressCallback, isLabelImage = false }) {
   const result = await readImageArrayBuffer(
     null,
     await fetchBinaryContent(imageUrlObj, progressCallback),
-    imageUrlObj.pathname.split('/').at(-1)
+    imageUrlObj.pathname.split('/').pop()
   )
   result.webWorker.terminate()
   return await toMultiscaleSpatialImage(result.image)
@@ -94,9 +94,9 @@ export async function createViewerFromUrl(
     if (isZarr(url)) {
       fetchedImage = await toMultiscaleSpatialImage(urlObj)
     } else {
-      const arrayBuffer = await fetchBinaryContent(url, progressCallback)
+      const arrayBuffer = await fetchBinaryContent(urlObj, progressCallback)
       fileObjects.push(
-        new File([new Blob([arrayBuffer])], urlObj.pathname.split('/').at(-1))
+        new File([new Blob([arrayBuffer])], urlObj.pathname.split('/').pop())
       )
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -43,16 +43,16 @@ export async function createViewerFromFiles(el, files, use2D = false) {
 
 async function makeImage({ image, progressCallback, isLabelImage = false }) {
   if (!image) return null
+
+  const imageUrlObj = new URL(image, document.location)
+
   if (isZarr(image)) {
-    return await toMultiscaleSpatialImage(
-      new URL(image, document.location),
-      isLabelImage
-    )
+    return await toMultiscaleSpatialImage(imageUrlObj, isLabelImage)
   }
 
   const result = await readImageArrayBuffer(
     null,
-    await fetchBinaryContent(image, progressCallback),
+    await fetchBinaryContent(imageUrlObj, progressCallback),
     image.split('/').slice(-1)[0]
   )
   result.webWorker.terminate()
@@ -90,10 +90,9 @@ export async function createViewerFromUrl(
   let fetchedImage
   const fileObjects = []
   for (const url of files) {
+    const urlObj = new URL(url, document.location)
     if (isZarr(url)) {
-      fetchedImage = await toMultiscaleSpatialImage(
-        new URL(url, document.location)
-      )
+      fetchedImage = await toMultiscaleSpatialImage(urlObj)
     } else {
       const arrayBuffer = await fetchBinaryContent(url, progressCallback)
       fileObjects.push(

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ async function makeImage({ image, progressCallback, isLabelImage = false }) {
   const result = await readImageArrayBuffer(
     null,
     await fetchBinaryContent(imageUrlObj, progressCallback),
-    image.split('/').slice(-1)[0]
+    imageUrlObj.pathname.split('/').at(-1)
   )
   result.webWorker.terminate()
   return await toMultiscaleSpatialImage(result.image)
@@ -96,7 +96,7 @@ export async function createViewerFromUrl(
     } else {
       const arrayBuffer = await fetchBinaryContent(url, progressCallback)
       fileObjects.push(
-        new File([new Blob([arrayBuffer])], url.split('/').slice(-1)[0])
+        new File([new Blob([arrayBuffer])], urlObj.pathname.split('/').at(-1))
       )
     }
   }


### PR DESCRIPTION
In case URL contains options (common for S3 presigned URLs for example),
the code would not be able to extract filename correctly
and 'IO' flow selection would not work.
Fix this by using URL API to robustly parse filename.

Also, change `fetchBinaryContent()` to work with URL objects instead of strings.
URL objects are usually used in the calling code anyway,
so it makes sense to just pass them.