### PR TITLE
fix(ImJoyAPI): Tweak setVolumeScatteringBlend naming

### DIFF
--- a/src/ImJoyPluginAPI.js
+++ b/src/ImJoyPluginAPI.js
@@ -354,12 +354,12 @@ class ImJoyPluginAPI {
     return this.viewer.getCroppingPlanes()
   }
 
-  setVolumetricScatteringBlend(scatteringBlend, name) {
-    this.viewer.setVolumetricScatteringBlend(scatteringBlend, name)
+  setImageVolumeScatteringBlend(scatteringBlend, name) {
+    this.viewer.setImageVolumeScatteringBlend(scatteringBlend, name)
   }
 
-  getVolumetricScatteringBlend(name) {
-    return this.viewer.getVolumetricScatteringBlend(name)
+  getImageVolumeScatteringBlend(name) {
+    return this.viewer.getImageVolumeScatteringBlend(name)
   }
 }
 

--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -1175,7 +1175,7 @@ const createViewer = async (
     return store.itkVtkView
   }
 
-  publicAPI.setVolumetricScatteringBlend = (scatteringBlend, name) => {
+  publicAPI.setImageVolumeScatteringBlend = (scatteringBlend, name) => {
     if (typeof name === 'undefined') {
       name = context.images.selectedName
     }
@@ -1189,7 +1189,7 @@ const createViewer = async (
     })
   }
 
-  publicAPI.getVolumetricScatteringBlend = name => {
+  publicAPI.getImageVolumeScatteringBlend = name => {
     if (typeof name === 'undefined') {
       name = context.images.selectedName
     }

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -117,11 +117,11 @@ test('Test createViewer', async t => {
   viewer.setBackgroundColor(TEST_VIEWER_STYLE.backgroundColor)
 
   const VALUE = 0.3
-  viewer.setVolumetricScatteringBlend(VALUE)
+  viewer.setImageVolumeScatteringBlend(VALUE)
   t.equal(
-    viewer.getVolumetricScatteringBlend(),
+    viewer.getImageVolumeScatteringBlend(),
     VALUE,
-    'getVolumetricScatteringBlend matches setVolumetricScatteringBlend'
+    'getImageVolumeScatteringBlend matches setImageVolumeScatteringBlend'
   )
 
   viewer.setUICollapsed(false)


### PR DESCRIPTION
- Consistent `Image` prefix for image-related parameters
- Shorter, more consistent `Volume` over `Volumetric`