### PR TITLE
fix(MultiscaleSpatialImage): transpose of ITK direction matrix

### DIFF
--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -112,12 +112,12 @@ const makeMat4 = ({ direction, origin, spacing }) => {
 }
 
 const makeIndexToWorld = ({ direction: inDirection, origin, spacing }) => {
+  // ITK (and VTKMath) uses row-major index axis, but gl-matrix uses column-major. Transpose.
   const DIMENSIONS = 3
-  const direction = [...inDirection]
+  const direction = Array(inDirection.length)
   for (let idx = 0; idx < DIMENSIONS; ++idx) {
     for (let col = 0; col < DIMENSIONS; ++col) {
-      // ITK (and VTKMath) uses row-major index axis, but gl-matrix uses column-major. Transpose.
-      direction[col + idx * 3] = direction[idx + col * DIMENSIONS]
+      direction[col + idx * 3] = inDirection[idx + col * DIMENSIONS]
     }
   }
 


### PR DESCRIPTION
This direction matrix was incorrectly transposed
```
-0 0 -1
1 -0 0
0 -1 0
```

This file has the above direction matrix:
http://download.alleninstitute.org/informatics-archive/converted_mouse_ccf/average_template/average_template_50.nii.gz

Related: https://github.com/InsightSoftwareConsortium/itkwidgets/issues/596