### PR TITLE
fix(ZarrMultiscaleSpatialImage): Constrain concurrency for large server

### DIFF
--- a/src/Context/ViewerMachineContext.js
+++ b/src/Context/ViewerMachineContext.js
@@ -3,6 +3,8 @@ import LayersMachineContext from './LayersMachineContext'
 import ImagesMachineContext from './ImagesMachineContext'
 import WidgetsMachineContext from './WidgetsMachineContext'
 
+export const MAX_CONCURRENCY = 128
+
 const defaultRenderingViewContainerStyle = {
   position: 'relative',
   width: '100%',
@@ -115,7 +117,7 @@ class ViewerMachineContext {
 
   // Has the user set the number of available processors, or will we determine
   // that dynamically from the client?
-  maxConcurrency = 0
+  maxConcurrency = MAX_CONCURRENCY
 
   // Main machine context
   main = null

--- a/src/IO/ZarrMultiscaleSpatialImage.js
+++ b/src/IO/ZarrMultiscaleSpatialImage.js
@@ -237,8 +237,11 @@ class ZarrMultiscaleSpatialImage extends MultiscaleSpatialImage {
   constructor(zarrStoreParser, scaleInfo, imageType, maxConcurrency = 0) {
     super(scaleInfo, imageType)
     this.dataSource = zarrStoreParser
-    if (maxConcurrency === 0) {
-      maxConcurrency = window.navigator.hardwareConcurrency
+    if (maxConcurrency !== 0) {
+      maxConcurrency = Math.min(
+        window.navigator.hardwareConcurrency,
+        maxConcurrency
+      )
     }
     this.rpcQueue = new PQueue({ concurrency: maxConcurrency })
   }

--- a/src/IO/toMultiscaleSpatialImage.js
+++ b/src/IO/toMultiscaleSpatialImage.js
@@ -39,7 +39,7 @@ async function itkImageToInMemoryMultiscaleSpatialImage(image, isLabelImage) {
 async function toMultiscaleSpatialImage(
   image,
   isLabelImage = false,
-  maxConcurrency = 0
+  maxConcurrency
 ) {
   let multiscaleImage = null
   if (image instanceof MultiscaleSpatialImage) {

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -8,6 +8,7 @@ import vtk from 'vtk.js/Sources/vtk'
 import createViewer from '../src/createViewer'
 import './customElementsDefineOverride.js'
 import referenceUIMachineOptions from '../src/UI/reference-ui'
+import { MAX_CONCURRENCY } from '../src/Context/ViewerMachineContext'
 
 const testImage3DPath = 'base/test/data/input/HeadMRVolume.nrrd'
 const testLabelImage3DPath = 'base/test/data/input/HeadMRVolumeLabels.nrrd'
@@ -36,7 +37,7 @@ const TEST_VIEWER_STYLE = {
 }
 
 const baselineConfig = JSON.parse(
-  '{"viewerConfigVersion":"0.3","uiMachineOptions":"reference","xyLowerLeft":false,"renderingViewContainerStyle":{"position":"relative","width":"600px","height":"600px","minHeight":"600px","minWidth":"600px","maxHeight":"600px","maxWidth":"600px","margin":"0","padding":"0","top":"0","left":"0","overflow":"hidden"},"uiCollapsed":true,"main":{"backgroundColor":[0.7,0.2,0.8],"units":"mm"},"maxConcurrency":0}'
+  `{"viewerConfigVersion":"0.3","uiMachineOptions":"reference","xyLowerLeft":false,"renderingViewContainerStyle":{"position":"relative","width":"600px","height":"600px","minHeight":"600px","minWidth":"600px","maxHeight":"600px","maxWidth":"600px","margin":"0","padding":"0","top":"0","left":"0","overflow":"hidden"},"uiCollapsed":true,"main":{"backgroundColor":[0.7,0.2,0.8],"units":"mm"},"maxConcurrency":${MAX_CONCURRENCY}}`
 )
 
 function makePointSet() {


### PR DESCRIPTION
While we want to constrain the max concurrency when there are many more logical processors on the client than on the server, we should also do the same when there are many more logical processors on the server than the client.