### PR TITLE
fix(fuseImagesUtils): allocate correct size fused array

### DIFF
--- a/src/Rendering/VTKJS/Images/fuseImagesUtils.js
+++ b/src/Rendering/VTKJS/Images/fuseImagesUtils.js
@@ -19,7 +19,9 @@ export const parseByComponent = scaleImage => {
 }
 
 export const countElements = componentInfo =>
-  componentInfo.map(({ data }) => data.length).reduce(sum)
+  componentInfo
+    .map(({ data, srcComponentCount }) => data.length / srcComponentCount)
+    .reduce(sum)
 
 export const getLargestTypeByBytes = componentInfo =>
   componentInfo


### PR DESCRIPTION
For multi-component images, fused data array was too big.