### PR TITLE
fix(createViewer): Handle TAKE_SCREENSHOT event

### DIFF
--- a/src/createViewer.js
+++ b/src/createViewer.js
@@ -181,6 +181,8 @@ const createViewer = async (
           case 'SCREENSHOT_TAKEN':
             eventEmitter.emit('screenshotTaken', event.data)
             break
+          case 'TAKE_SCREENSHOT':
+            break
           default:
             throw new Error(`Unexpected event type: ${event.type}`)
         }


### PR DESCRIPTION
To address with itkwidgets:

```
caught Error: Unexpected event type: TAKE_SCREENSHOT
    at itkVtkViewer.js:161:457719
    at itkVtkViewer.js:2:1470699
    at Set.forEach (<anonymous>)
    at Object.send (itkVtkViewer.js:2:1470671)
    at e.sendTo (itkVtkViewer.js:2:1457639)
    at e._exec (itkVtkViewer.js:2:1458205)
    at e.exec (itkVtkViewer.js:2:1467591)
    at e.execute (itkVtkViewer.js:2:1459688)
    at e.update (itkVtkViewer.js:2:1460057)
    at itkVtkViewer.js:2:1457049
```