### PR TITLE
Ingestion fixes for 2D images 

### DIFF
--- a/src/IO/InMemoryMultiscaleSpatialImage.js
+++ b/src/IO/InMemoryMultiscaleSpatialImage.js
@@ -1,4 +1,7 @@
-import MultiscaleSpatialImage, { storeImage } from './MultiscaleSpatialImage'
+import MultiscaleSpatialImage, {
+  ensure3dDirection,
+  storeImage,
+} from './MultiscaleSpatialImage'
 import componentTypeToTypedArray from './componentTypeToTypedArray'
 
 import {
@@ -195,6 +198,9 @@ async function chunkImage(image, chunkSize) {
   ).map(({ min, max }) => [min, max])
 
   const orderByDims = orderBy(dims)
+
+  const direction3d = ensure3dDirection(image.direction)
+
   const scaleInfo = {
     dims,
     coords: new Coords(image, [...dims].reverse()), // Coords assumes xyz
@@ -202,7 +208,7 @@ async function chunkImage(image, chunkSize) {
     chunkSize: orderByDims(toDimensionMap(CXYZT, sizeCXYZTChunks)),
     arrayShape: orderByDims(toDimensionMap(CXYZT, sizeCXYZTElements)),
     ranges,
-    direction: image.direction && chunkArray(3, [...image.direction].reverse()), // reverse to cast xyz to zyx
+    direction: chunkArray(3, [...direction3d].reverse()), // reverse to cast xyz to zyx
   }
 
   return { scaleInfo, chunksStride, chunks }

--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -222,10 +222,9 @@ class MultiscaleSpatialImage {
     const spacing = new Array(this.spatialDims.length)
     for (let index = 0; index < this.spatialDims.length; index++) {
       const dim = this.spatialDims[index]
-      if (info.coords.has(dim)) {
-        const coords = await info.coords.get(dim)
-        // if has one entry for dim, just use, else find difference between first 2
-        spacing[index] = coords.length === 1 ? coords[0] : coords[1] - coords[0]
+      const dimCoords = await info.coords.get(dim)
+      if (dimCoords && dimCoords.length >= 2) {
+        spacing[index] = dimCoords[1] - dimCoords[0]
       } else {
         spacing[index] = 1.0
       }

--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -86,7 +86,7 @@ const extentToBounds = (ex, indexToWorld) => {
   return bounds
 }
 
-const ensure3dDirection = d => {
+export const ensure3dDirection = d => {
   if (d.length >= 9) {
     return d
   }

--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -224,7 +224,8 @@ class MultiscaleSpatialImage {
       const dim = this.spatialDims[index]
       if (info.coords.has(dim)) {
         const coords = await info.coords.get(dim)
-        spacing[index] = coords[1] - coords[0]
+        // if has one entry for dim, just use, else find difference between first 2
+        spacing[index] = coords.length === 1 ? coords[0] : coords[1] - coords[0]
       } else {
         spacing[index] = 1.0
       }


### PR DESCRIPTION
Image would not show up if `direction` matrix was 2D or if a dimension's spatial coordinate array had only 1 element.