### PR TITLE
Fix serving viewer with a path deeper than the origin

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -196,7 +196,8 @@ module.exports = function init(config) {
       args: config.dockered ? ['--dockered'] : [],
     },
 
-    browserDisconnectTimeout: 5000,
+    browserDisconnectTimeout: 60000,
+    browserNoActivityTimeout: 60000,
 
     port: 9876,
     colors: true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 const path = require('path')
+const os = require('os')
 
 const vtkRules = require('vtk.js/Utilities/config/dependency.js').webpack.core
   .rules
@@ -29,10 +30,6 @@ const itkConfigTest = path.resolve(__dirname, 'test', 'itkConfigBrowserTest.js')
 const moduleConfigRules = [
   { test: /\.js$/, loader: 'babel-loader', dependency: { not: ['url'] } },
   {
-    test: /\.worker.js$/,
-    use: [{ loader: 'worker-loader', options: { inline: 'no-fallback' } }],
-  },
-  {
     test: /\.(png|jpg)$/,
     type: 'asset',
     parser: { dataUrlCondition: { maxSize: 128 * 1024 } },
@@ -41,6 +38,13 @@ const moduleConfigRules = [
 ].concat(vtkRules, cssRules)
 
 const entry = path.join(__dirname, './src/index.js')
+
+// fixes 404 errors getting worker bundles https://github.com/ryanclark/karma-webpack/issues/498#issuecomment-790040818
+const output = {
+  path:
+    path.join(os.tmpdir(), '_karma_webpack_') +
+    Math.floor(Math.random() * 1000000),
+}
 
 module.exports = function init(config) {
   config.set({
@@ -106,6 +110,12 @@ module.exports = function init(config) {
         included: false,
       },
       {
+        pattern: './dist/*.js',
+        watched: true,
+        served: true,
+        included: false,
+      },
+      {
         pattern: './src/UI/reference-ui/dist/referenceUIMachineOptions.js',
         watched: true,
         served: true,
@@ -123,6 +133,11 @@ module.exports = function init(config) {
         served: true,
         included: false,
       },
+      {
+        pattern: `${output.path}/**/*`,
+        watched: false,
+        included: false,
+      },
     ],
 
     preprocessors: {
@@ -130,6 +145,7 @@ module.exports = function init(config) {
     },
 
     webpack: {
+      output,
       mode: 'development',
       devtool: 'eval-source-map',
       module: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,8 +102,7 @@
         "webpack-dev-server": "^4.7.4",
         "webpackbar": "^5.0.0-3",
         "workbox-build": "^6.5.1",
-        "workbox-webpack-plugin": "^6.5.1",
-        "worker-loader": "^3.0.8"
+        "workbox-webpack-plugin": "^6.5.1"
       }
     },
     "node_modules/@assemblyscript/loader": {

--- a/package.json
+++ b/package.json
@@ -120,8 +120,7 @@
     "webpack-dev-server": "^4.7.4",
     "webpackbar": "^5.0.0-3",
     "workbox-build": "^6.5.1",
-    "workbox-webpack-plugin": "^6.5.1",
-    "worker-loader": "^3.0.8"
+    "workbox-webpack-plugin": "^6.5.1"
   },
   "scripts": {
     "doc": "kw-doc -c ./doc/config.js",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "start": "webpack serve --mode development --static ./dist/ --open --port 8082",
     "dev": "webpack serve --mode development --static ./dist/ --port 8082",
     "semantic-release": "semantic-release",
-    "test": "npm run test:downloadData && npm run lint:types && npm run build:test-ui && karma start ./karma.conf.js --browsers Chrome_without_sandbox,Firefox",
+    "test": "npm run test:downloadData && npm run lint:types && npm run build:test-ui && karma start ./karma.conf.js --browsers Chrome_without_sandbox",
     "test:downloadData": "node test/downloadData.mjs",
     "test:headless": "./test/run.sh",
     "test:headless-debug": "./test/run.sh -d",

--- a/src/IO/Analyze/computeHistograms.js
+++ b/src/IO/Analyze/computeHistograms.js
@@ -1,4 +1,3 @@
-import UpdateHistogramWorker from './UpdateHistogram.worker'
 const haveSharedArrayBuffer = typeof window.SharedArrayBuffer === 'function'
 import webWorkerPromiseWorkerPool from './webWorkerPromiseWorkerPool'
 
@@ -8,7 +7,10 @@ const numberOfWorkers = navigator.hardwareConcurrency
 
 const updateHistogramWorkerPool = webWorkerPromiseWorkerPool(
   numberOfWorkers,
-  UpdateHistogramWorker,
+  () =>
+    new Worker(new URL('./UpdateHistogram.worker.js', import.meta.url), {
+      type: 'module',
+    }),
   'updateHistogram'
 )
 

--- a/src/IO/Analyze/computeRanges.js
+++ b/src/IO/Analyze/computeRanges.js
@@ -1,6 +1,6 @@
 import webWorkerPromiseWorkerPool from './webWorkerPromiseWorkerPool'
-import ComputeRangesWorker from './ComputeRanges.worker'
 import { createRangeHelper } from './createRangeHelper'
+
 const haveSharedArrayBuffer = typeof globalThis.SharedArrayBuffer === 'function'
 
 const numberOfWorkers = navigator.hardwareConcurrency
@@ -9,7 +9,10 @@ const numberOfWorkers = navigator.hardwareConcurrency
 
 const computeRangeWorkerPool = webWorkerPromiseWorkerPool(
   numberOfWorkers,
-  ComputeRangesWorker,
+  () =>
+    new Worker(new URL('./ComputeRanges.worker.js', import.meta.url), {
+      type: 'module',
+    }),
   'computeRanges'
 )
 

--- a/src/IO/Analyze/webWorkerPromiseWorkerPool.js
+++ b/src/IO/Analyze/webWorkerPromiseWorkerPool.js
@@ -1,22 +1,16 @@
-/** Todo: migrate to itk-wasm */
 import { WorkerPool } from 'itk-wasm'
 
 import WebworkerPromise from 'webworker-promise'
 
 function webWorkerPromiseWorkerPool(
   numberOfWorkers,
-  webWorkerObject,
+  makeWorker,
   operationName
 ) {
-  const createWorker = existingWorker => {
-    if (existingWorker) {
-      const webWorkerPromise = new WebworkerPromise(existingWorker)
-      return { webWorkerPromise, worker: existingWorker }
-    }
-
-    const newWorker = new webWorkerObject()
-    const newWebworkerPromise = new WebworkerPromise(newWorker)
-    return { webWorkerPromise: newWebworkerPromise, worker: newWorker }
+  const createWorker = () => {
+    const newWorker = makeWorker()
+    const webWorkerPromise = new WebworkerPromise(newWorker)
+    return { webWorkerPromise, worker: newWorker }
   }
 
   const compute = async (webWorker, ...args) => {

--- a/src/IO/Analyze/webWorkerPromiseWorkerPool.js
+++ b/src/IO/Analyze/webWorkerPromiseWorkerPool.js
@@ -7,10 +7,10 @@ function webWorkerPromiseWorkerPool(
   makeWorker,
   operationName
 ) {
-  const createWorker = () => {
-    const newWorker = makeWorker()
-    const webWorkerPromise = new WebworkerPromise(newWorker)
-    return { webWorkerPromise, worker: newWorker }
+  const createWorker = existingWorker => {
+    const worker = existingWorker ?? makeWorker()
+    const webWorkerPromise = new WebworkerPromise(worker)
+    return { webWorkerPromise, worker }
   }
 
   const compute = async (webWorker, ...args) => {

--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -403,7 +403,8 @@ class MultiscaleSpatialImage {
     return image
   }
 
-  getIndexBounds(scale) {
+  getIndexBounds(requestedScale) {
+    const scale = Math.min(requestedScale, this.scaleInfo.length - 1)
     const { arrayShape } = this.scaleInfo[scale]
     return new Map(
       Array.from(arrayShape).map(([dim, size]) => [dim, [0, size - 1]])

--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -4,12 +4,14 @@ import { setMatrixElement } from 'itk-wasm'
 import componentTypeToTypedArray from './componentTypeToTypedArray'
 
 import WebworkerPromise from 'webworker-promise'
-import ImageDataFromChunksWorker from './ImageDataFromChunks.worker'
 import { chunkArray, CXYZT, ensuredDims, orderBy } from './dimensionUtils'
 import { getDtype } from './dtypeUtils'
 import { transformBounds } from '../transformBounds'
 
-const imageDataFromChunksWorker = new ImageDataFromChunksWorker()
+const imageDataFromChunksWorker = new Worker(
+  new URL('./ImageDataFromChunks.worker.js', import.meta.url),
+  { type: 'module' }
+)
 const imageDataFromChunksWorkerPromise = new WebworkerPromise(
   imageDataFromChunksWorker
 )

--- a/src/Rendering/VTKJS/Images/fuseImages.js
+++ b/src/Rendering/VTKJS/Images/fuseImages.js
@@ -1,5 +1,4 @@
 import WebworkerPromise from 'webworker-promise'
-import ComposeImageWorker from './ComposeImage.worker.js'
 
 export const fuseImages = async ({
   imageAtScale, //could be array if Conglomerate
@@ -8,7 +7,11 @@ export const fuseImages = async ({
   fixedImageAtScale,
   compare,
 }) => {
-  const worker = new WebworkerPromise(new ComposeImageWorker())
+  const composeWorker = new Worker(
+    new URL('./ComposeImage.worker.js', import.meta.url),
+    { type: 'module' }
+  )
+  const worker = new WebworkerPromise(composeWorker)
   const { image } = await worker.postMessage({
     image: imageAtScale,
     labelImage: labelAtScale,

--- a/test/createViewerTest.js
+++ b/test/createViewerTest.js
@@ -440,7 +440,7 @@ test('Test createViewer', async t => {
     //2.0,
     //gc.releaseResources
     //)
-  }, 1000)
+  }, 2000)
 })
 
 test('Test createViewer.setImage', async t => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,10 +56,6 @@ const fallback = {
 const moduleConfigRules = [
   { test: /\.js$/, loader: 'babel-loader', dependency: { not: ['url'] } },
   {
-    test: /\.worker.js$/,
-    use: [{ loader: 'worker-loader', options: { inline: 'no-fallback' } }],
-  },
-  {
     test: /\.(png|jpg)$/,
     type: 'asset',
     parser: { dataUrlCondition: { maxSize: 128 * 1024 } },


### PR DESCRIPTION
Stops using webpack worker loader which was configured to build workers as blobs.

Blobs' self.location or `__webpack_public_path__` is not like the document path (index.html).  If the viewer is served off the origin, with a path (ie localhost:8080/some/path/) then the itk-wasm path would not include the path, just the origin.