### PR TITLE
Color range fix

### DIFF
--- a/doc/content/docs/viewer.md
+++ b/doc/content/docs/viewer.md
@@ -1,4 +1,5 @@
-## title: Progressive Web App
+title: Progressive Web App
+---
 
 The [default ITK/VTK Viewer page](https://kitware.github.io/itk-vtk-viewer/app/) lets you drag and drop or select a data file from your local filesystem to visualize. Once you have loaded data with this [progressive web app](https://en.wikipedia.org/wiki/Progressive_Web_Apps), the app will also work offline.
 

--- a/src/Rendering/Images/createImageRenderingActor.js
+++ b/src/Rendering/Images/createImageRenderingActor.js
@@ -310,6 +310,9 @@ const cleanColorRanges = (c, { data: { name } }) => {
     actorContext.colorRangeBoundsAutoAdjust = new Map(
       [...Array(componentCount).keys()].map(c => [c, true])
     )
+    actorContext.piecewiseFunctionPointsAutoAdjust = new Map(
+      [...Array(componentCount).keys()].map(c => [c, true])
+    )
 
     actorContext.dirtyColorRanges = false
   }


### PR DESCRIPTION
When adding a component dynamically to an image, the piecewise points
were not clamped to the color range on the second component.