### PR TITLE
Fixes: negative direction vectors and different number of scales in fixed/moving compare images

### DIFF
--- a/src/IO/MultiscaleSpatialImage.js
+++ b/src/IO/MultiscaleSpatialImage.js
@@ -7,6 +7,7 @@ import WebworkerPromise from 'webworker-promise'
 import { chunkArray, CXYZT, ensuredDims, orderBy } from './dimensionUtils'
 import { getDtype } from './dtypeUtils'
 import { transformBounds } from '../transformBounds'
+import { makeIndexToWorld } from '../internalUtils'
 
 const imageDataFromChunksWorker = new Worker(
   new URL('./ImageDataFromChunks.worker.js', import.meta.url),
@@ -94,42 +95,6 @@ export const ensure3dDirection = d => {
   }
   // Pad 2D with Z dimension
   return [d[0], d[1], 0, d[2], d[3], 0, 0, 0, 1]
-}
-
-const makeMat4 = ({ direction, origin, spacing }) => {
-  const mat = mat4.create()
-  mat4.fromTranslation(mat, origin)
-
-  mat[0] = direction[0]
-  mat[1] = direction[1]
-  mat[2] = direction[2]
-  mat[4] = direction[3]
-  mat[5] = direction[4]
-  mat[6] = direction[5]
-  mat[8] = direction[6]
-  mat[9] = direction[7]
-  mat[10] = direction[8]
-
-  return mat4.scale(mat, mat, spacing)
-}
-
-const makeIndexToWorld = ({ direction: inDirection, origin, spacing }) => {
-  // ITK (and VTKMath) uses row-major index axis, but gl-matrix uses column-major. Transpose.
-  const DIMENSIONS = 3
-  const direction = Array(inDirection.length)
-  for (let idx = 0; idx < DIMENSIONS; ++idx) {
-    for (let col = 0; col < DIMENSIONS; ++col) {
-      direction[col + idx * 3] = inDirection[idx + col * DIMENSIONS]
-    }
-  }
-
-  const origin3d = [...origin]
-  if (origin3d[2] === undefined) origin3d[2] = 0
-
-  const spacing3d = [...spacing]
-  if (spacing3d[2] === undefined) spacing3d[2] = 1
-
-  return makeMat4({ direction, origin: origin3d, spacing: spacing3d })
 }
 
 export const worldBoundsToIndexBounds = ({

--- a/src/Rendering/VTKJS/Main/croppingPlanes.js
+++ b/src/Rendering/VTKJS/Main/croppingPlanes.js
@@ -1,4 +1,4 @@
-import { mat4, vec3, quat } from 'gl-matrix'
+import { mat4, vec3, quat, vec4 } from 'gl-matrix'
 import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData'
 import { transformVec3 } from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers'
 import vtkMath from 'vtk.js/Sources/Common/Core/Math'
@@ -8,7 +8,7 @@ import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox'
 import toggleCroppingPlanes from './toggleCroppingPlanes'
 import HandlesInPixelsImageCroppingWidget from '../Widgets/HandlesInPixelsImageCroppingWidget'
 import { transformBounds } from '../../../transformBounds'
-import { arraysEqual } from '../../../internalUtils'
+import { arraysEqual, makeIndexToWorld } from '../../../internalUtils'
 
 export function getCropWidgetBounds(context, bounds = []) {
   const { croppingWidget } = context.main
@@ -176,11 +176,12 @@ export function updateCroppingParameters(context) {
   if (uninitialized) return
 
   // Put global bounds in image oriented space
-  const orientation = quat.fromMat3([], croppingVirtualImage.getDirection())
-  const worldToImageDirection = mat4.fromQuat(
-    [],
-    quat.invert(orientation, orientation)
-  )
+
+  const worldToImageDirection = makeIndexToWorld({
+    direction: croppingVirtualImage.getDirection(),
+    origin: [0, 0, 0],
+    spacing: [1, 1, 1],
+  })
 
   const orientedBox = transformBounds(
     worldToImageDirection,

--- a/src/internalUtils.js
+++ b/src/internalUtils.js
@@ -1,3 +1,5 @@
+import { mat4 } from 'gl-matrix'
+
 export function arraysEqual(a, b) {
   if (a === b) return true
   if (a == null || b == null) return false
@@ -6,4 +8,44 @@ export function arraysEqual(a, b) {
     if (a[i] !== b[i]) return false
   }
   return true
+}
+
+const makeMat4 = ({ direction, origin, spacing }) => {
+  const mat = mat4.create()
+  mat4.fromTranslation(mat, origin)
+
+  mat[0] = direction[0]
+  mat[1] = direction[1]
+  mat[2] = direction[2]
+  mat[4] = direction[3]
+  mat[5] = direction[4]
+  mat[6] = direction[5]
+  mat[8] = direction[6]
+  mat[9] = direction[7]
+  mat[10] = direction[8]
+
+  return mat4.scale(mat, mat, spacing)
+}
+
+export const makeIndexToWorld = ({
+  direction: inDirection,
+  origin,
+  spacing,
+}) => {
+  // ITK (and VTKMath) uses row-major index axis, but gl-matrix uses column-major. Transpose.
+  const DIMENSIONS = 3
+  const direction = Array(inDirection.length)
+  for (let idx = 0; idx < DIMENSIONS; ++idx) {
+    for (let col = 0; col < DIMENSIONS; ++col) {
+      direction[col + idx * 3] = inDirection[idx + col * DIMENSIONS]
+    }
+  }
+
+  const origin3d = [...origin]
+  if (origin3d[2] === undefined) origin3d[2] = 0
+
+  const spacing3d = [...spacing]
+  if (spacing3d[2] === undefined) spacing3d[2] = 1
+
+  return makeMat4({ direction, origin: origin3d, spacing: spacing3d })
 }


### PR DESCRIPTION
The image cropping planes were outside the image when the direction vectors of an image "mirror" the spacing.  Example direction vectors: `[-1, -0, -0, -0, -1, -0, 0, 0, -1]`

When a fixed and moving image have different number of scales in MultiscaleImage, there was errors in `updateRenderedImage`