### PR TITLE
fix: default label image weight for background label is 0.0

### DIFF
--- a/src/Rendering/VTKJS/Images/applyRenderedImage.js
+++ b/src/Rendering/VTKJS/Images/applyRenderedImage.js
@@ -348,7 +348,7 @@ function applyRenderedImage(context, { data: { name } }) {
       if (!labelImageWeights.has(label)) {
         // 0 is usually the background label -- suppress it
         label === 0
-          ? labelImageWeights.set(label, 0.1)
+          ? labelImageWeights.set(label, 0.0)
           : labelImageWeights.set(label, 1.0)
         labelImageWeightAdded = true
       }


### PR DESCRIPTION
Instead of 0.1.

To address: https://github.com/InsightSoftwareConsortium/itkwidgets/issues/683